### PR TITLE
Register metrics from aggregator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -129,6 +129,7 @@ func main() {
 		WithPath("/metrics").
 		WithPort(strconv.Itoa(metricsPort)).
 		WithServiceMonitor().
+		WithCollectors(metrics.GetMetricsAggregator().GetMetrics()).
 		GetConfig()
 	if err = customMetrics.ConfigureMetrics(context.TODO(), *metricsConfig); err != nil {
 		log.Error(err, "Failed to run metrics server")


### PR DESCRIPTION
Currently the metrics are not being served on the metrics handler because they are not registered.