### PR TITLE
Change the bundle generation script to not include CSVs

### DIFF
--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -45,28 +45,6 @@ if not os.path.exists(version_dir):
 
 # Initialize CRD array in CSV
 csv['spec']['customresourcedefinitions']['owned'] = []
-
-# Copy all CSV files over to the bundle output dir:
-# Copy all CRD files over to the bundle output dir:
-crd_files = [ f for f in os.listdir('deploy/crds') if f.endswith('_crd.yaml') ]
-for file_name in crd_files:
-    full_path = os.path.join('deploy/crds', file_name)
-    if (os.path.isfile(os.path.join('deploy/crds', file_name))):
-        shutil.copy(full_path, os.path.join(version_dir, file_name))
-    # Load CRD so we can use attributes from it
-    with open("deploy/crds/{}".format(file_name), "r") as stream:
-        crd = yaml.load(stream)
-    # Update CSV template customresourcedefinitions key
-    csv['spec']['customresourcedefinitions']['owned'].append(
-        {
-            "name": crd["metadata"]["name"],
-            "description": crd["spec"]["names"]["kind"],
-            "displayName": crd["spec"]["names"]["kind"],
-            "kind": crd["spec"]["names"]["kind"],
-            "version": crd["spec"]["version"]
-        }
-    )
-
 csv['spec']['install']['spec']['clusterPermissions'] = []
 
 # Add osd-metrics-exporter role to the CSV:


### PR DESCRIPTION
Since the operator does not have CRDs of its own the generate bundle script fails because there are no CRDs in the specified directory.
