### PR TITLE
Added update servicemonitor permission for operator

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -62,3 +62,4 @@ rules:
   verbs:
   - get
   - create
+  - update


### PR DESCRIPTION
The operator also needs permissions to update servicemonitors.