### PR TITLE
Change cluster-admin metric to be read from user group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+
+# Boilerplate
+.venv

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	userv1 "github.com/openshift/api/user/v1"
 	customMetrics "github.com/openshift/operator-custom-metrics/pkg/metrics"
 	operatorConfig "github.com/openshift/osd-metrics-exporter/config"
 	"github.com/openshift/osd-metrics-exporter/pkg/apis"
@@ -130,6 +131,11 @@ func main() {
 		os.Exit(1)
 	}
 	err = configv1.Install(mgr.GetScheme())
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	err = userv1.Install(mgr.GetScheme())
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -32,6 +32,24 @@ rules:
     - patch
     - update
 - apiGroups:
+    - user.openshift.io
+  resources:
+    - groups
+  verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - user.openshift.io
+  resources:
+    - groups/finalizers
+  verbs:
+    - create
+    - patch
+    - update
+- apiGroups:
   - ""
   resources:
   - pods

--- a/pkg/controller/add_controllers.go
+++ b/pkg/controller/add_controllers.go
@@ -2,10 +2,11 @@ package controller
 
 import (
 	"github.com/openshift/osd-metrics-exporter/pkg/controller/clusterrole"
+	"github.com/openshift/osd-metrics-exporter/pkg/controller/group"
 	"github.com/openshift/osd-metrics-exporter/pkg/controller/oauth"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, oauth.Add, clusterrole.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, oauth.Add, clusterrole.Add, group.Add)
 }

--- a/pkg/controller/group/group_controller.go
+++ b/pkg/controller/group/group_controller.go
@@ -1,0 +1,122 @@
+package group
+
+import (
+	"context"
+
+	userv1 "github.com/openshift/api/user/v1"
+	"github.com/openshift/osd-metrics-exporter/pkg/controller/utils"
+	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	clusterAdminGroupName = "cluster-admins"
+	finalizer             = "osd-metrics-exporter/finalizer"
+)
+
+var log = logf.Log.WithName("controller_group")
+
+// Add creates a new Group Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileGroup{
+		client:            mgr.GetClient(),
+		scheme:            mgr.GetScheme(),
+		metricsAggregator: metrics.GetMetricsAggregator(),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("group-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource Group
+	err = c.Watch(&source.Kind{Type: &userv1.Group{}}, &handler.EnqueueRequestForObject{}, predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return createEvent.Meta.GetName() == clusterAdminGroupName
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return deleteEvent.Meta.GetName() == clusterAdminGroupName
+		},
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			return updateEvent.MetaNew.GetName() == clusterAdminGroupName
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return genericEvent.Meta.GetName() == clusterAdminGroupName
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileGroup implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileGroup{}
+
+// ReconcileGroup reconciles a Group object
+type ReconcileGroup struct {
+	client            client.Client
+	scheme            *runtime.Scheme
+	metricsAggregator *metrics.AdoptionMetricsAggregator
+}
+
+// Reconcile reads that state of the cluster for a Group object and makes changes based on the state read
+// and what is in the Group.Spec
+func (r *ReconcileGroup) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling Group")
+
+	// Fetch the Group group
+	group := &userv1.Group{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, group)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+	if group.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !utils.ContainsString(group.Finalizers, finalizer) {
+			controllerutil.AddFinalizer(group, finalizer)
+			if err := r.client.Update(context.Background(), group); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+		r.metricsAggregator.SetClusterAdmin(len(group.Users) > 0)
+	} else {
+		r.metricsAggregator.SetClusterAdmin(false)
+		if utils.ContainsString(group.Finalizers, finalizer) {
+			controllerutil.RemoveFinalizer(group, finalizer)
+			if err := r.client.Update(context.Background(), group); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/group/group_controller_test.go
+++ b/pkg/controller/group/group_controller_test.go
@@ -1,0 +1,76 @@
+package group
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	userv1 "github.com/openshift/api/user/v1"
+	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileGroup_Reconcile(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		users       []string
+		result      int
+		delete      bool
+	}{
+		{
+			name:   "empty cluster-admins group",
+			result: 0,
+		},
+		{
+			name:   "single user",
+			users:  []string{"abc"},
+			result: 1,
+		},
+		{
+			name:   "deletion set",
+			users:  []string{"abc"},
+			result: 0,
+			delete: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := userv1.Install(scheme.Scheme)
+			require.NoError(t, err)
+			group := &userv1.Group{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterAdminGroupName},
+				Users:      tc.users,
+			}
+			if tc.delete {
+				now := metav1.Now()
+				group.DeletionTimestamp = &now
+			}
+			fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, group)
+			reconcileGroup := &ReconcileGroup{
+				client:            fakeClient,
+				scheme:            scheme.Scheme,
+				metricsAggregator: metrics.NewMetricsAggregator(time.Second * 10),
+			}
+			_, err = reconcileGroup.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: clusterAdminGroupName},
+			})
+			require.NoError(t, err)
+			err = fakeClient.Get(context.Background(), client.ObjectKey{Name: clusterAdminGroupName}, group)
+			require.NoError(t, err)
+			if tc.delete {
+				require.NotContains(t, group.Finalizers, finalizer)
+			} else {
+				require.Contains(t, group.Finalizers, finalizer)
+			}
+			metric := reconcileGroup.metricsAggregator.GetClusterRoleMetric()
+			value := testutil.ToFloat64(metric)
+			require.EqualValues(t, tc.result, value)
+		})
+	}
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -1,0 +1,11 @@
+package utils
+
+
+func ContainsString(stringArray []string, candidate string) bool {
+	for _, s := range stringArray {
+		if s == candidate {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The exporter contains a metric which indicates whether the cluster-admin is enabled for the cluster.
In the current version the exporter simply looks for the existence of the cluster-admin _ClusterRole_
to determine this. However the _ClusterRole_ is always present. The feature is enabled by adding
users to the `cluster-admin` _Group_. So the PR contains the following changes:

- Change the current `clusterrole-controller` to simply remove the finalizer when present. This is
to ensure proper cleanup.
- Modify the tests for the above controller to ensure that the finalizer is always removed.
- Add a new controller which looks for the presence of a _Group_ called `cluster-admins` and whenever
present check for the users in this group. If greater than 1 then indicate that the cluster admin
is enabled.
- Tests for the above controller.
