### PR TITLE
OSD-6853: Use `REPO_DIGEST` for CatalogSource

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -8,6 +8,8 @@ parameters:
   required: true
 - name: IMAGE_TAG
   required: true
+- name: REPO_DIGEST
+  required: true
 - name: REPO_NAME
   value: osd-metrics-exporter
   required: true
@@ -71,7 +73,7 @@ objects:
         name: osd-metrics-exporter-registry
         namespace: openshift-osd-metrics
       spec:
-        image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+        image: ${REPO_DIGEST}
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Use `REPO_DIGEST` (e.g. `quay.io/app-sre/osd-metrics-exporter-registry@sha256:abc1234...`) instead of the tag-based URI (e.g. `quay.io/app-sre/osd-metrics-exporter-registry:production-0f3da87`) to reference the CatalogSource image.

[OSD-6853](https://issues.redhat.com/browse/OSD-6853)