### PR TITLE
OSD-6851: docker inspect with :latest

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -8,6 +8,8 @@ CURRENT_DIR=$(dirname "$0")
 
 BASE_IMG="osd-metrics-exporter"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+# FIXME: Use ${GIT_HASH} instead of latest here. The easy way to do that would
+# be to not override this at all, since the default is correct.
 IMG="${BASE_IMG}:latest"
 
 GIT_HASH=$(git rev-parse --short=7 HEAD)

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -9,9 +9,11 @@ GIT_HASH=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT_COUNT=$(git rev-list $(git rev-list --max-parents=0 HEAD)..HEAD --count)
 
 # Get the repo URI + image digest
-REPO_DIGEST=$(docker image inspect ${QUAY_IMAGE}:${GIT_HASH} --format '{{index .RepoDigests 0}}')
+# FIXME: This should inspect ${QUAY_IMAGE}:${GIT_HASH} instead, but we're
+# overriding ${IMG} in app_sre_build_deploy.sh. Fix that.
+REPO_DIGEST=$(docker image inspect ${QUAY_IMAGE}:latest --format '{{index .RepoDigests 0}}')
 if [[ -z "$REPO_DIGEST" ]]; then
-    echo "Couldn't discover REPO_DIGEST for ${QUAY_IMAGE}:${GIT_HASH}!"
+    echo "Couldn't discover REPO_DIGEST for ${QUAY_IMAGE}:latest!"
     exit 1
 fi
 


### PR DESCRIPTION
We're overriding `$IMG` in app_sre_build_deploy.sh, so we don't have `${QUAY_IMAGE}:${GIT_HASH}` available locally for `docker image inspect`. For now, inspect with `latest` instead. (Later, quit overriding `$IMG`.)

This was missed in #38.