### PR TITLE
OSD-6851: Another docker inspect fix

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -8,8 +8,7 @@ CURRENT_DIR=$(dirname "$0")
 
 BASE_IMG="osd-metrics-exporter"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
-# FIXME: Use ${GIT_HASH} instead of latest here. The easy way to do that would
-# be to not override this at all, since the default is correct.
+# FIXME: Don't override this. The default (set in standard.mk) is fine.
 IMG="${BASE_IMG}:latest"
 
 GIT_HASH=$(git rev-parse --short=7 HEAD)

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -11,9 +11,10 @@ GIT_COMMIT_COUNT=$(git rev-list $(git rev-list --max-parents=0 HEAD)..HEAD --cou
 # Get the repo URI + image digest
 # FIXME: This should inspect ${QUAY_IMAGE}:${GIT_HASH} instead, but we're
 # overriding ${IMG} in app_sre_build_deploy.sh. Fix that.
-REPO_DIGEST=$(docker image inspect ${QUAY_IMAGE}:latest --format '{{index .RepoDigests 0}}')
+LOCAL_IMG=osd-metrics-exporter:latest
+REPO_DIGEST=$(docker image inspect ${LOCAL_IMG} --format '{{index .RepoDigests 0}}')
 if [[ -z "$REPO_DIGEST" ]]; then
-    echo "Couldn't discover REPO_DIGEST for ${QUAY_IMAGE}:latest!"
+    echo "Couldn't discover REPO_DIGEST for ${LOCAL_IMG}!"
     exit 1
 fi
 


### PR DESCRIPTION
In #38 we were trying to `docker image inspect` the *right* image tag, but didn't realize `$IMG` was being overridden. In #39 we tried to fix that, but did it wrong. Trying again.

[OSD-6851](https://issues.redhat.com/browse/OSD-6851)