### PR TITLE
Use explicit tag for yq in image catalog build

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -35,7 +35,7 @@ REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
         curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-osd-metrics-exporter.yaml" | \
-	    docker run --rm -i quay.io/app-sre/yq yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref'
+	    docker run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref'
     )
 
     delete=false


### PR DESCRIPTION
We've been relying on the quay.io/app-sre/yq image to provide a consistent and predictable yq for a certain step in the image catalog build in the appsre pipeline. Unfortunately, this implicitly uses the `latest` tag, which is a moving target. It appears as though "they" have recently begun tagging 4.x versions as `latest`, whereas we were relying on 3.

So with this commit, we explicitly request quay.io/app-sre/yq:3.