### PR TITLE
Revert "OSD-6853: Use `REPO_DIGEST` for CatalogSource"

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -8,8 +8,6 @@ parameters:
   required: true
 - name: IMAGE_TAG
   required: true
-- name: REPO_DIGEST
-  required: true
 - name: REPO_NAME
   value: osd-metrics-exporter
   required: true
@@ -73,7 +71,7 @@ objects:
         name: osd-metrics-exporter-registry
         namespace: openshift-osd-metrics
       spec:
-        image: ${REPO_DIGEST}
+        image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Reverts openshift/osd-metrics-exporter#37

The `REPO_DIGEST` functionality in qontract-reconcile hit a speed bump. Revert this while we work it out.