### PR TITLE
Revert "Revert "OSD-6853: Use `REPO_DIGEST` for CatalogSource""

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -8,6 +8,8 @@ parameters:
   required: true
 - name: IMAGE_TAG
   required: true
+- name: REPO_DIGEST
+  required: true
 - name: REPO_NAME
   value: osd-metrics-exporter
   required: true
@@ -71,7 +73,7 @@ objects:
         name: osd-metrics-exporter-registry
         namespace: openshift-osd-metrics
       spec:
-        image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+        image: ${REPO_DIGEST}
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Reverts openshift/osd-metrics-exporter#44

Depends-On: ~https://github.com/app-sre/qontract-reconcile/pull/1486~
Depends-On: ~https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/17433~
Depends-On: ~https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/17443~

[OSD-6853](https://issues.redhat.com/browse/OSD-6853)