### PR TITLE
OSD-6833: bumping origin-operator-registry to 4.9 (latest)

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -104,7 +104,7 @@ REGISTRY_IMG="quay.io/app-sre/osd-metrics-exporter-registry"
 DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
 
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:4.5
+FROM quay.io/openshift/origin-operator-registry:4.9
 
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer --permissive


### PR DESCRIPTION
as Clair reported an issue with the 4.5 version in quay, bumping origin-operator-registry to 4.9 (latest)