### PR TITLE
OSD-6853: Skip operator/catalog build/push if image exists

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -5,6 +5,7 @@
 set -exv
 
 CURRENT_DIR=$(dirname "$0")
+source $CURRENT_DIR/common.sh
 
 BASE_IMG="osd-metrics-exporter"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
@@ -13,17 +14,22 @@ IMG="${BASE_IMG}:latest"
 
 GIT_HASH=$(git rev-parse --short=7 HEAD)
 
-# build the image
-BUILD_CMD="docker build" IMG="$IMG" make docker-build
+# Don't rebuild the image if it already exists in the repository
+if image_exists_in_repo "${QUAY_IMAGE}:${GIT_HASH}"; then
+    echo "Skipping operator image build/push"
+else
+    # build the image
+    BUILD_CMD="docker build" IMG="$IMG" make docker-build
 
-# push the image
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:${IMG}" \
-    "docker://${QUAY_IMAGE}:latest"
+    # push the image
+    skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+        "docker-daemon:${IMG}" \
+        "docker://${QUAY_IMAGE}:latest"
 
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:${IMG}" \
-    "docker://${QUAY_IMAGE}:${GIT_HASH}"
+    skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+        "docker-daemon:${IMG}" \
+        "docker://${QUAY_IMAGE}:${GIT_HASH}"
+fi
 
 # create and push staging image catalog
 "$CURRENT_DIR"/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE"

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,44 @@
+## image_exits_in_repo IMAGE_URI
+#
+# Checks whether IMAGE_URI -- e.g. quay.io/app-sre/osd-metrics-exporter:abcd123
+# -- exists in the remote repository.
+# If so, returns success.
+# If the image does not exist, but the query was otherwise successful, returns
+# failure.
+# If the query fails for any reason, prints an error and *exits* nonzero.
+image_exists_in_repo() {
+    local image_uri=$1
+    local output
+
+    output=$(skopeo inspect docker://${image_uri} 2>&1)
+    if [[ $? -eq 0 ]]; then
+        # The image exists. Sanity check the output.
+        local digest=$(echo $output | jq -r .Digest)
+        if [[ -z "$digest" ]]; then
+            echo "Unexpected error: skopeo inspect succeeded, but output contained no .Digest"
+            echo "Here's the output:"
+            echo "$output"
+            exit 1
+        fi
+        echo "Image ${image_uri} exists with digest $digest."
+        return 0
+    elif [[ "$output" == *"manifest unknown"* ]]; then
+        # We were able to talk to the repository, but the tag doesn't exist.
+        # This is the normal "green field" case.
+        echo "Image ${image_uri} does not exist in the repository."
+        return 1
+    else
+        # Any other error. For example:
+        #   - "unauthorized: access to the requested resource is not
+        #     authorized". This happens not just on auth errors, but if we
+        #     reference a repository that doesn't exist.
+        #   - "no such host".
+        #   - Network or other infrastructure failures.
+        # In all these cases, we want to bail, because we don't know whether
+        # the image exists (and we'd likely fail to push it anyway).
+        echo "Error querying the repository for ${image_uri}:"
+        echo "$output"
+        exit 1
+    fi
+}
+


### PR DESCRIPTION
Since we are referencing operator and catalog images by digest now, we want to make sure those by-digest URIs are permanent. In (rare) cases where we would rebuild the image, it was possible to lose such a URI, as follows:

- Build image with tag `foo`. Push it to the repository. It gets digest `abc123`.
- Later, or on another CD server -- i.e. somewhere that same image doesn't already exist locally -- build the image again, with tag `foo`. Push it to the repository. It gets digest `def456`. And since there's no longer a tag that references the image with digest `abc123`, that image gets purged from the repository.

This would result in pull errors for any existing deployment referencing the image by the purged digest.

There are two ways we could have fixed this:
- Always push an extra tag corresponding to the digest. This would ensure there's always a tag referencing that image, so it would stick around permanently. The disadvantages being
  1. extra repository storage;
  2. multiple images with the same content, which could be confusing to debug.
- (This PR): Check whether the image already exists by tag and skip building it again if so.

This PR contains two commits:
1. Introduce a library function to check whether an image exists in the remote repository; and use it to condition build/push of *operator* images.
2. Use that same function to condition saas bundle creation and build/push of *catalog* images.

[OSD-6853](https://issues.redhat.com/browse/OSD-6853)