### PR TITLE
Schedule Operator Pods To Infra Nodes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,6 +12,18 @@ spec:
       labels:
         name: osd-metrics-exporter
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
       serviceAccountName: osd-metrics-exporter
       containers:
         - name: osd-metrics-exporter


### PR DESCRIPTION
OSD operators should be scheduled on infra nodes.
https://issues.redhat.com/browse/OSD-6635