### PR TITLE
Set IMAGE_REPOSITORY environment variable for image builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ tags
 # Boilerplate
 .operator-sdk/*
 .venv
+
+# Local docker configuration
+.docker/*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+IMAGE_REPOSITORY?=app-sre
+
 include boilerplate/generated-includes.mk
 
 .PHONY: boilerplate-update


### PR DESCRIPTION
The `IMAGE_REPOSITORY` environment variable is required for image build in the app-sre pipelines.
