### PR TITLE
Set registry and user token for quay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 IMAGE_REPOSITORY?=app-sre
+REGISTRY_USER?=$(QUAY_USER)
+REGISTRY_TOKEN?=$(QUAY_TOKEN)
 
 include boilerplate/generated-includes.mk
 


### PR DESCRIPTION
The app-sre pipelines set the `QUAY_USER` and `QUAY_TOKEN` environment variables but the boilerplate scripts expect `REGISTRY_USER` and `REGISTRY_TOKEN` to be set.