### PR TITLE
[OSD-8061] Expose the metrics for proxy utilization

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/cache"

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -14,6 +14,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch  
+- apiGroups:
     - rbac.authorization.k8s.io
   resources:
     - clusterroles

--- a/pkg/controller/add_controllers.go
+++ b/pkg/controller/add_controllers.go
@@ -4,9 +4,10 @@ import (
 	"github.com/openshift/osd-metrics-exporter/pkg/controller/clusterrole"
 	"github.com/openshift/osd-metrics-exporter/pkg/controller/group"
 	"github.com/openshift/osd-metrics-exporter/pkg/controller/oauth"
+	"github.com/openshift/osd-metrics-exporter/pkg/controller/proxy"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, oauth.Add, clusterrole.Add, group.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, oauth.Add, clusterrole.Add, group.Add, proxy.Add)
 }

--- a/pkg/controller/proxy/proxy_controller.go
+++ b/pkg/controller/proxy/proxy_controller.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	"context"
+
+	openshiftapi "github.com/openshift/api/config/v1"
+	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_proxy")
+
+// Add creates a new Proxy Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileProxy{
+		client:            mgr.GetClient(),
+		scheme:            mgr.GetScheme(),
+		metricsAggregator: metrics.GetMetricsAggregator(),
+	}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("proxy-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource Proxy
+	err = c.Watch(&source.Kind{Type: &openshiftapi.Proxy{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileProxy implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileProxy{}
+
+// ReconcileProxy reconciles a Proxy object
+type ReconcileProxy struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client            client.Client
+	scheme            *runtime.Scheme
+	metricsAggregator *metrics.AdoptionMetricsAggregator
+}
+
+// Reconcile reads that state of the cluster for a Proxy object and makes changes based on the state read
+// and what is in the Proxy.Spec
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileProxy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling Proxy")
+
+	// Fetch the Proxy instance
+	instance := &openshiftapi.Proxy{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+	// init metics
+	var proxyHTTP = "0"
+	var proxyHTTPS = "0"
+	var proxyTrustedCA = "0"
+	var proxyEnabled = 0
+	// when http proxy in status
+	if instance.Status.HTTPProxy != "" {
+		proxyHTTP = "1"
+		proxyEnabled = 1
+	}
+	//when https proxy in status
+	if instance.Status.HTTPSProxy != "" {
+		proxyHTTPS = "1"
+		proxyEnabled = 1
+	}
+	//when trusted ca in spec
+	if instance.Spec.TrustedCA.Name != "" {
+		proxyTrustedCA = "1"
+	}
+	// aggregate metrics
+	r.metricsAggregator.SetClusterProxy(proxyHTTP, proxyHTTPS, proxyTrustedCA, proxyEnabled)
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/proxy/proxy_controller_test.go
+++ b/pkg/controller/proxy/proxy_controller_test.go
@@ -1,0 +1,106 @@
+package proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	openshiftapi "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	testName        = "test"
+	testNamespace   = "test"
+	proxyHTTPLabel  = "http"
+	proxyHTTPSLabel = "https"
+	proxyCALabel    = "trusted_ca"
+	proxyEnabled    = float64(1)
+)
+
+func makeTestProxy(name, namespace string, proxySpec openshiftapi.ProxySpec, proxyStatus openshiftapi.ProxyStatus) *openshiftapi.Proxy {
+	proxy := &openshiftapi.Proxy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       proxySpec,
+		Status:     proxyStatus,
+	}
+	return proxy
+}
+func TestReconcileProxy_Reconcile(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		proxyStatus openshiftapi.ProxyStatus
+		proxySpec   openshiftapi.ProxySpec
+	}{
+		{
+			name: "with ca",
+			proxySpec: openshiftapi.ProxySpec{
+				TrustedCA: openshiftapi.ConfigMapNameReference{
+					Name: "test",
+				},
+			},
+			proxyStatus: openshiftapi.ProxyStatus{
+				HTTPProxy:  "http://example.com",
+				HTTPSProxy: "https://example.com",
+			},
+		},
+		{
+			name:      "no ca",
+			proxySpec: openshiftapi.ProxySpec{},
+			proxyStatus: openshiftapi.ProxyStatus{
+				HTTPProxy:  "http://example.com",
+				HTTPSProxy: "https://example.com",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
+			done := metricsAggregator.Run()
+			defer close(done)
+			err := openshiftapi.Install(scheme.Scheme)
+			require.NoError(t, err)
+
+			fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, makeTestProxy(testName, testNamespace, tc.proxySpec, tc.proxyStatus))
+			reconciler := ReconcileProxy{
+				client:            fakeClient,
+				metricsAggregator: metricsAggregator,
+			}
+			result, err := reconciler.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      testName,
+				},
+			})
+			require.NoError(t, err)
+
+			// sleep to allow the aggregator to aggregate metrics in the background
+			time.Sleep(time.Second * 3)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			var testProxy openshiftapi.Proxy
+			err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testName, Namespace: testNamespace}, &testProxy)
+			require.NoError(t, err)
+			// setup metric
+			metric := metricsAggregator.GetClusterProxyMetric()
+			metricWith := metric.With(prometheus.Labels{proxyHTTPLabel: "1", proxyHTTPSLabel: "1", proxyCALabel: "1"})
+			// enable metric
+			metricWith.Set(proxyEnabled)
+			metricEnabled := testutil.ToFloat64(metricWith)
+			require.EqualValues(t, 1, metricEnabled, "metric enabled")
+			// disable metric
+			metricWith.Set(0)
+			metricDisabled := testutil.ToFloat64(metricWith)
+			require.EqualValues(t, 0, metricDisabled, "metric enabled")
+
+		})
+	}
+}

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -9,15 +9,11 @@ import (
 )
 
 const (
-<<<<<<< HEAD
 	providerLabel    = "provider"
-	osdExporterValue = "osd-exporter"
-=======
-	providerLabel   = "provider"
-	proxyHTTPLabel  = "http"
-	proxyHTTPSLabel = "https"
-	proxyCALabel    = "trusted_ca"
->>>>>>> 10e10d3 ([OSD-8061] Expose the metrics for proxy utilization)
+	osdExporterValue = "osd_exporter"
+	proxyHTTPLabel   = "http"
+	proxyHTTPSLabel  = "https"
+	proxyCALabel     = "trusted_ca"
 )
 
 var knownIdentityProviderTypes = []configv1.IdentityProviderType{
@@ -62,7 +58,7 @@ func NewMetricsAggregator(aggregationInterval time.Duration) *AdoptionMetricsAgg
 		clusterProxy: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "cluster_proxy",
 			Help:        "Indicates cluster proxy state",
-			ConstLabels: map[string]string{"name": "osd_exporter"},
+			ConstLabels: map[string]string{"name": osdExporterValue},
 		}, []string{proxyHTTPLabel, proxyHTTPSLabel, proxyCALabel}),
 		providerMap:         make(map[providerKey][]configv1.IdentityProviderType),
 		aggregationInterval: aggregationInterval,

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -9,8 +9,15 @@ import (
 )
 
 const (
+<<<<<<< HEAD
 	providerLabel    = "provider"
 	osdExporterValue = "osd-exporter"
+=======
+	providerLabel   = "provider"
+	proxyHTTPLabel  = "http"
+	proxyHTTPSLabel = "https"
+	proxyCALabel    = "trusted_ca"
+>>>>>>> 10e10d3 ([OSD-8061] Expose the metrics for proxy utilization)
 )
 
 var knownIdentityProviderTypes = []configv1.IdentityProviderType{
@@ -34,6 +41,7 @@ type AdoptionMetricsAggregator struct {
 	identityProviders   *prometheus.GaugeVec
 	clusterAdmin        prometheus.Gauge
 	providerMap         map[providerKey][]configv1.IdentityProviderType
+	clusterProxy        *prometheus.GaugeVec
 	mutex               sync.Mutex
 	aggregationInterval time.Duration
 }
@@ -51,6 +59,11 @@ func NewMetricsAggregator(aggregationInterval time.Duration) *AdoptionMetricsAgg
 			Help:        "Indicates if the cluster-admin role is enabled",
 			ConstLabels: map[string]string{"name": osdExporterValue},
 		}),
+		clusterProxy: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "cluster_proxy",
+			Help:        "Indicates cluster proxy state",
+			ConstLabels: map[string]string{"name": "osd_exporter"},
+		}, []string{proxyHTTPLabel, proxyHTTPSLabel, proxyCALabel}),
 		providerMap:         make(map[providerKey][]configv1.IdentityProviderType),
 		aggregationInterval: aggregationInterval,
 	}
@@ -120,8 +133,16 @@ func (a *AdoptionMetricsAggregator) SetClusterAdmin(enabled bool) {
 	}
 }
 
+func (a *AdoptionMetricsAggregator) SetClusterProxy(proxyHTTP string, proxyHTTPS string, proxyTrustedCA string, proxyEnabled int) {
+	a.clusterProxy.With(prometheus.Labels{
+		proxyHTTPLabel:  proxyHTTP,
+		proxyHTTPSLabel: proxyHTTPS,
+		proxyCALabel:    proxyTrustedCA,
+	}).Set(float64(proxyEnabled))
+}
+
 func (a *AdoptionMetricsAggregator) GetMetrics() []prometheus.Collector {
-	return []prometheus.Collector{a.identityProviders, a.clusterAdmin}
+	return []prometheus.Collector{a.identityProviders, a.clusterAdmin, a.clusterProxy}
 }
 
 func (a *AdoptionMetricsAggregator) GetClusterRoleMetric() prometheus.Gauge {
@@ -130,4 +151,8 @@ func (a *AdoptionMetricsAggregator) GetClusterRoleMetric() prometheus.Gauge {
 
 func (a *AdoptionMetricsAggregator) GetIdentityProviderMetric() *prometheus.GaugeVec {
 	return a.identityProviders
+}
+
+func (a *AdoptionMetricsAggregator) GetClusterProxyMetric() *prometheus.GaugeVec {
+	return a.clusterProxy
 }


### PR DESCRIPTION
Added proxy controller with WIP tests

for tests, I'm trying to see if there's a way to hook into `reconciler.Reconcile` result to verify that `metricsAggregator.SetClusterProxy` is called with expected values when running 
```
TestReconcileProxy_Reconcile/with_ca
TestReconcileProxy_Reconcile/no_ca
```