### PR TITLE
[OSD-12072] expose _id as label for clusterID

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,53 @@ A prometheus exporter to expose metrics about various features used in Openshift
 
 1. Identity Provider
 2. Cluster Admin
+
+# Local development without OLM
+
+1. Create `Namespace`, `Role` and `RoleBinding`. Requires [yq](https://github.com/mikefarah/yq).
+
+```
+$ for k in "Namespace" "Role" "RoleBinding"; do; k=$k yq '.objects[].spec.resources[] | select(.kind==strenv(k))' < hack/olm-registry/olm-artifacts-template.yaml|  oc create -f -; done
+```
+
+2. Create `ClusterRole`, `ClusterRoleBinding` and `ServiceAccount`. 
+
+```
+$ oc -n openshift-osd-metrics create -f deploy/cluster_role_binding.yaml
+clusterrolebinding.rbac.authorization.k8s.io/osd-metrics-exporter created
+$ oc -n openshift-osd-metrics create -f deploy/cluster_role.yaml
+clusterrole.rbac.authorization.k8s.io/osd-metrics-exporter created
+$ oc -n openshift-osd-metrics create -f deploy/service_account.yaml
+serviceaccount/osd-metrics-exporter created
+```
+
+3. Requires operator-sdk < 1.X
+
+```
+$ operator-sdk version
+operator-sdk version: "v0.17.2", commit: "0258db0119e8e18e15d035532427c329fce1e871", kubernetes version: "v1.17.2", go version: "go1.18.2 linux/amd64"
+```
+
+4. Optionally authenticate as the `serviceaccount`.
+
+```
+$ oc login $(oc get infrastructures cluster -o json | jq -r '.status.apiServerURL') --token $(oc -n openshift-osd-metrics serviceaccounts get-token osd-metrics-exporter)
+```
+
+5. Switch to project
+
+```
+$ oc project openshift-osd-metrics
+Now using project "openshift-osd-metrics" on server "https://api.sno.dofinn.xyz:6443".
+```
+
+6. Run the operator
+
+```
+$ operator-sdk run --local
+INFO[0000] Running the operator locally in namespace openshift-osd-metrics.
+{"level":"info","ts":1655546577.210883,"logger":"cmd","msg":"Operator Version: 0.0.1"}
+{"level":"info","ts":1655546577.2109017,"logger":"cmd","msg":"Go Version: go1.18.2"}
+{"level":"info","ts":1655546577.2109056,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
+...
+```

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -17,6 +17,7 @@ rules:
   - config.openshift.io
   resources:
   - proxies
+  - clusterversions
   verbs:
   - get
   - list

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -3,9 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: osd-metrics-exporter
 subjects:
-- kind: ServiceAccount
-  name: osd-metrics-exporter
-  namespace: osd-adoption-exporter-metrics
+  - kind: ServiceAccount
+    name: osd-metrics-exporter
+    namespace: openshift-osd-metrics
 roleRef:
   kind: ClusterRole
   name: osd-metrics-exporter

--- a/pkg/controller/proxy/proxy_controller.go
+++ b/pkg/controller/proxy/proxy_controller.go
@@ -2,6 +2,8 @@ package proxy
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	openshiftapi "github.com/openshift/api/config/v1"
 	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
@@ -17,6 +19,8 @@ import (
 )
 
 var log = logf.Log.WithName("controller_proxy")
+
+const EnvClusterID = "CLUSTER_ID"
 
 // Add creates a new Proxy Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -71,6 +75,12 @@ type ReconcileProxy struct {
 func (r *ReconcileProxy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Proxy")
+
+	uuid := os.Getenv(EnvClusterID)
+	if uuid == "" {
+		return reconcile.Result{}, fmt.Errorf("Cluster ID returned as empty string")
+	}
+	r.metricsAggregator.SetClusterID(uuid)
 
 	// Fetch the Proxy instance
 	instance := &openshiftapi.Proxy{}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OSD-12072

Why expose the `_id` label? 

RecordingRules can now be created by SRE to form a standard set of labels (_id, region, provider, version) that will be used to accommodate every metric being written via remoteWrite to our centralized observability service. This allows for drill down on these labels and additionally enables removal of pod/instance labels that are somewhat required to avoid the issue of duplicate timestamps in a centralized service. 