### PR TITLE
[OSD-11464] Add gosec linter to CI.

### DIFF
--- a/.golangci-extras.yml
+++ b/.golangci-extras.yml
@@ -1,0 +1,4 @@
+linters:
+  disable-all: true
+  enable:
+  - gosec

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,6 @@ include boilerplate/generated-includes.mk
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
+
+# Enable additional golangci-lint rules
+GOLANGCI_OPTIONAL_CONFIG := .golangci-extras.yml


### PR DESCRIPTION
Add .golanci-extras.yml file to test for errors detected by adding the `gosec` linter.

The linter will be added to boilerplate [in the future](https://github.com/openshift/boilerplate/pull/206), so any errors should be removed before then.