### PR TITLE
[WIP] Move permission sets to minimize surface area of access cluster-wide

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -10,8 +10,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - config.openshift.io
@@ -21,7 +19,7 @@ rules:
   verbs:
   - get
   - list
-  - watch  
+  - watch
 - apiGroups:
     - rbac.authorization.k8s.io
   resources:
@@ -29,16 +27,12 @@ rules:
   verbs:
     - get
     - list
-    - patch
-    - update
     - watch
 - apiGroups:
     - rbac.authorization.k8s.io
   resources:
     - clusterroles/finalizers
   verbs:
-    - create
-    - patch
     - update
 - apiGroups:
     - user.openshift.io
@@ -47,28 +41,13 @@ rules:
   verbs:
     - get
     - list
-    - patch
-    - update
     - watch
 - apiGroups:
     - user.openshift.io
   resources:
     - groups/finalizers
   verbs:
-    - create
-    - patch
     - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
 - apiGroups:
   - ""
   resources:
@@ -76,17 +55,10 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - apps
+  - ""
   resources:
-  - deployments
-  - daemonsets
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
+  - configmaps
   verbs:
   - get
-  - create
-  - update
+  - list
+  - watch

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,0 +1,32 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-metrics-exporter
+  namespace: openshift-osd-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-metrics-exporter
+  namespace: openshift-osd-metrics
+subjects:
+  - kind: ServiceAccount
+    name: osd-metrics-exporter
+    namespace: openshift-osd-metrics
+roleRef:
+  kind: Role
+  name: osd-metrics-exporter
+  namespace: openshift-osd-metrics
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Currently the ClusterRole is more permissive than needed. This PR refactors the permission set up to limit as many permissions to the workload's namespace as possible, and remove all Update/Patch permissions except where absolutely necessary. 