### PR TITLE
removing user dofinn

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ reviewers:
 - jharrington22
 - dustman9000
 - bdematte
-- dofinn
 - dkeohane
 - mrWinston
 - macgregor
@@ -11,7 +10,6 @@ approvers:
 - jharrington22
 - dustman9000
 - bdematte
-- dofinn
 - dkeohane
 - macgregor
 - iamkirkbater


### PR DESCRIPTION
OHSS:15434
This PR serves the purpose of removing Dominic Finn from owners as he has left Red Hat.