### PR TITLE
[OSD-14155] Adding _id label to limited_support_enabled metric 

### DIFF
--- a/controllers/limited_support/limited_support_controller.go
+++ b/controllers/limited_support/limited_support_controller.go
@@ -16,6 +16,7 @@ package limited_support
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,8 @@ const (
 	limitedSupportConfigMapNamespace = "openshift-osd-metrics"
 )
 
+const EnvClusterID = "CLUSTER_ID"
+
 var log = logf.Log.WithName("controller_limited_support")
 
 // LimitedSupportConfigMapReconciler reconciles a ConfigMap object
@@ -47,6 +50,12 @@ type LimitedSupportConfigMapReconciler struct {
 func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling Limited Support ConfigMap")
+
+	uuid := os.Getenv(EnvClusterID)
+	if uuid == "" {
+		return ctrl.Result{}, fmt.Errorf("cluster ID returned as empty string")
+	}
+	r.MetricsAggregator.SetClusterID(uuid)
 
 	// Fetch the ConfigMap openshift-osd-metrics/limited-support
 	cfgMap := &corev1.ConfigMap{}

--- a/controllers/limited_support/limited_support_controller.go
+++ b/controllers/limited_support/limited_support_controller.go
@@ -52,7 +52,10 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 	reqLogger.Info("Reconciling Limited Support ConfigMap")
 
 	// Fetch the ConfigMap openshift-osd-metrics/limited-support
-	uuid := os.Getenv(EnvClusterID)
+	uuid, ok := os.LookupEnv(EnvClusterID)
+	if !ok || uuid == "" {
+	  return reconcile.Result{}, fmt.Errorf("cluster ID unset or returned as empty string")
+	}
 	cfgMap := &corev1.ConfigMap{}
 	ns := limitedSupportConfigMapNamespace
 	err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: limitedSupportConfigMapName}, cfgMap)

--- a/controllers/limited_support/limited_support_controller.go
+++ b/controllers/limited_support/limited_support_controller.go
@@ -54,7 +54,7 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 	// Fetch the ConfigMap openshift-osd-metrics/limited-support
 	uuid, ok := os.LookupEnv(EnvClusterID)
 	if !ok || uuid == "" {
-	  return reconcile.Result{}, fmt.Errorf("cluster ID unset or returned as empty string")
+		return ctrl.Result{}, fmt.Errorf("cluster ID unset or returned as empty string")
 	}
 	cfgMap := &corev1.ConfigMap{}
 	ns := limitedSupportConfigMapNamespace
@@ -71,7 +71,6 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
-
 	reqLogger.Info(fmt.Sprintf("Found ConfigMap %v", limitedSupportConfigMapName))
 	r.MetricsAggregator.SetLimitedSupport(uuid, true)
 	return ctrl.Result{}, nil

--- a/controllers/limited_support/limited_support_controller.go
+++ b/controllers/limited_support/limited_support_controller.go
@@ -67,7 +67,7 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
 			reqLogger.Info(fmt.Sprintf("Did not find ConfigMap %v", limitedSupportConfigMapName))
-			r.MetricsAggregator.SetLimitedSupport(false)
+			r.MetricsAggregator.SetLimitedSupport(uuid, 0)
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -75,7 +75,7 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 	}
 
 	reqLogger.Info(fmt.Sprintf("Found ConfigMap %v", limitedSupportConfigMapName))
-	r.MetricsAggregator.SetLimitedSupport(true)
+	r.MetricsAggregator.SetLimitedSupport(uuid, 1)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/limited_support/limited_support_controller.go
+++ b/controllers/limited_support/limited_support_controller.go
@@ -51,13 +51,8 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling Limited Support ConfigMap")
 
-	uuid := os.Getenv(EnvClusterID)
-	if uuid == "" {
-		return ctrl.Result{}, fmt.Errorf("cluster ID returned as empty string")
-	}
-	r.MetricsAggregator.SetClusterID(uuid)
-
 	// Fetch the ConfigMap openshift-osd-metrics/limited-support
+	uuid := os.Getenv(EnvClusterID)
 	cfgMap := &corev1.ConfigMap{}
 	ns := limitedSupportConfigMapNamespace
 	err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: limitedSupportConfigMapName}, cfgMap)
@@ -67,7 +62,7 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
 			reqLogger.Info(fmt.Sprintf("Did not find ConfigMap %v", limitedSupportConfigMapName))
-			r.MetricsAggregator.SetLimitedSupport(uuid, 0)
+			r.MetricsAggregator.SetLimitedSupport(uuid, false)
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -75,7 +70,7 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 	}
 
 	reqLogger.Info(fmt.Sprintf("Found ConfigMap %v", limitedSupportConfigMapName))
-	r.MetricsAggregator.SetLimitedSupport(uuid, 1)
+	r.MetricsAggregator.SetLimitedSupport(uuid, true)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/limited_support/limited_support_controller_test.go
+++ b/controllers/limited_support/limited_support_controller_test.go
@@ -91,7 +91,7 @@ limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 0
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			os.Setenv(EnvClusterID, tc.testEnvClusterID)
+			t.Setenv(EnvClusterID, tc.testEnvClusterID)
 			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
 			done := metricsAggregator.Run()
 			defer close(done)

--- a/controllers/limited_support/limited_support_controller_test.go
+++ b/controllers/limited_support/limited_support_controller_test.go
@@ -2,7 +2,6 @@ package limited_support
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 	"time"

--- a/controllers/limited_support/limited_support_controller_test.go
+++ b/controllers/limited_support/limited_support_controller_test.go
@@ -42,7 +42,7 @@ limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 1
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			os.Setenv(EnvClusterID, tc.testEnvClusterID)
+			t.Setenv(EnvClusterID, tc.testEnvClusterID)
 			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
 			done := metricsAggregator.Run()
 			defer close(done)

--- a/controllers/limited_support/limited_support_controller_test.go
+++ b/controllers/limited_support/limited_support_controller_test.go
@@ -2,6 +2,7 @@ package limited_support
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -26,19 +27,22 @@ func makeTestConfigMap(name string, namespace string) *corev1.ConfigMap {
 
 func TestReconcileLimitedSupportConfigMap_Reconcile(t *testing.T) {
 	for _, tc := range []struct {
-		name            string
-		expectedResults string
+		name             string
+		expectedResults  string
+		testEnvClusterID string
 	}{
 		{
-			name: "limited-support correct ConfigMap",
+			name:             "limited-support correct ConfigMap",
+			testEnvClusterID: "i-am-a-cluster-id",
 			expectedResults: `
 # HELP limited_support_enabled Indicates if limited support is enabled
 # TYPE limited_support_enabled gauge
-limited_support_enabled{name="osd_exporter"} 1
+limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 1
 `,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv(EnvClusterID, tc.testEnvClusterID)
 			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
 			done := metricsAggregator.Run()
 			defer close(done)
@@ -72,19 +76,22 @@ limited_support_enabled{name="osd_exporter"} 1
 	}
 
 	for _, tc := range []struct {
-		name            string
-		expectedResults string
+		name             string
+		expectedResults  string
+		testEnvClusterID string
 	}{
 		{
-			name: "limited-support invalid configMap",
+			name:             "limited-support invalid configMap",
+			testEnvClusterID: "i-am-a-cluster-id",
 			expectedResults: `
 # HELP limited_support_enabled Indicates if limited support is enabled
 # TYPE limited_support_enabled gauge
-limited_support_enabled{name="osd_exporter"} 0
+limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 0
 `,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv(EnvClusterID, tc.testEnvClusterID)
 			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
 			done := metricsAggregator.Run()
 			defer close(done)

--- a/main.go
+++ b/main.go
@@ -105,6 +105,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.Info("exporting cluster id to container env")
+	err = exportClusterID(mgr.GetAPIReader())
+	if err != nil {
+		setupLog.Error(err, "Failed to retrieve and export ClusterID")
+		os.Exit(1)
+	}
+
 	if err = (&configmap.ConfigMapReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
@@ -171,13 +178,6 @@ func main() {
 		GetConfig()
 	if err = customMetrics.ConfigureMetrics(context.TODO(), *metricsConfig); err != nil {
 		setupLog.Error(err, "Failed to run metrics server")
-		os.Exit(1)
-	}
-
-	setupLog.Info("exporting cluster id to container env")
-	err = exportClusterID(mgr.GetAPIReader())
-	if err != nil {
-		setupLog.Error(err, "Failed to retrieve and export ClusterID")
 		os.Exit(1)
 	}
 

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -9,14 +9,13 @@ import (
 )
 
 const (
-	providerLabel         = "provider"
-	osdExporterValue      = "osd_exporter"
-	proxyHTTPLabel        = "http"
-	proxyHTTPSLabel       = "https"
-	proxyCALabel          = "trusted_ca"
-	proxyCASubjectLabel   = "subject"
-	clusterIDLabel        = "_id"
-	limitedSupportEnabled = "limited_support_enabled"
+	providerLabel       = "provider"
+	osdExporterValue    = "osd_exporter"
+	proxyHTTPLabel      = "http"
+	proxyHTTPSLabel     = "https"
+	proxyCALabel        = "trusted_ca"
+	proxyCASubjectLabel = "subject"
+	clusterIDLabel      = "_id"
 )
 
 var knownIdentityProviderTypes = []configv1.IdentityProviderType{

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -90,6 +90,7 @@ func NewMetricsAggregator(aggregationInterval time.Duration) *AdoptionMetricsAgg
 		aggregationInterval: aggregationInterval,
 	}
 	collector.clusterAdmin.Set(0)
+	collector.SetLimitedSupport(clusterIDLabel, false)
 	return collector
 }
 

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -91,7 +91,6 @@ func NewMetricsAggregator(aggregationInterval time.Duration) *AdoptionMetricsAgg
 		aggregationInterval: aggregationInterval,
 	}
 	collector.clusterAdmin.Set(0)
-	//collector.limitedSupport.Set(0)
 	return collector
 }
 
@@ -157,12 +156,12 @@ func (a *AdoptionMetricsAggregator) SetClusterAdmin(enabled bool) {
 	}
 }
 
-func (a *AdoptionMetricsAggregator) SetLimitedSupport(uuid string, enabled float64) {
-        labels := prometheus.Labels{
-			clusterIDLabel: uuid,
-		}
+func (a *AdoptionMetricsAggregator) SetLimitedSupport(uuid string, enabled bool) {
+	labels := prometheus.Labels{
+		clusterIDLabel: uuid,
+	}
 
-	if enabled == 1 {
+	if enabled {
 		a.limitedSupport.With(labels).Set(1)
 
 	} else {

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -90,7 +91,8 @@ func NewMetricsAggregator(aggregationInterval time.Duration) *AdoptionMetricsAgg
 		aggregationInterval: aggregationInterval,
 	}
 	collector.clusterAdmin.Set(0)
-	collector.SetLimitedSupport(clusterIDLabel, false)
+	uuid := os.Getenv("CLUSTER_ID")
+	collector.SetLimitedSupport(uuid, false)
 	return collector
 }
 


### PR DESCRIPTION
In this commit, I added an _id label to the limited_support_metric to be picked up in the observatorium.
- Moved exportClusterID() in main.go to set CLUSTER_ID var at start up before creating metrics aggregator

https://issues.redhat.com/browse/OSD-14155