### PR TITLE
Refactor cluster id to be passed by value instead of by env var

### DIFF
--- a/controllers/configmap/configmap_controller_test.go
+++ b/controllers/configmap/configmap_controller_test.go
@@ -106,7 +106,7 @@ cluster_proxy_ca_expiry_timestamp{name="osd_exporter",subject="O=Default Company
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
+			metricsAggregator := metrics.NewMetricsAggregator(time.Second, "clusterId")
 			done := metricsAggregator.Run()
 			defer close(done)
 			err := corev1.AddToScheme(scheme.Scheme)
@@ -154,7 +154,7 @@ cluster_proxy_ca_valid{name="osd_exporter"} 0
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
+			metricsAggregator := metrics.NewMetricsAggregator(time.Second, "clusterId")
 			done := metricsAggregator.Run()
 			defer close(done)
 			err := corev1.AddToScheme(scheme.Scheme)

--- a/controllers/group/group_controller_test.go
+++ b/controllers/group/group_controller_test.go
@@ -54,7 +54,7 @@ func TestReconcileGroup_Reconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(group).Build()
 			reconcileGroup := &GroupReconciler{
 				Client:            fakeClient,
-				MetricsAggregator: metrics.NewMetricsAggregator(time.Second * 10),
+				MetricsAggregator: metrics.NewMetricsAggregator(time.Second*10, "cluster-id"),
 			}
 			_, err = reconcileGroup.Reconcile(context.TODO(), ctrl.Request{
 				NamespacedName: types.NamespacedName{Name: clusterAdminGroupName},

--- a/controllers/limited_support/limited_support_controller.go
+++ b/controllers/limited_support/limited_support_controller.go
@@ -50,8 +50,7 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 
 	// Fetch the ConfigMap openshift-osd-metrics/limited-support
 	cfgMap := &corev1.ConfigMap{}
-	ns := limitedSupportConfigMapNamespace
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: limitedSupportConfigMapName}, cfgMap)
+	err := r.Client.Get(ctx, types.NamespacedName{Namespace: limitedSupportConfigMapNamespace, Name: limitedSupportConfigMapName}, cfgMap)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/controllers/limited_support/limited_support_controller.go
+++ b/controllers/limited_support/limited_support_controller.go
@@ -16,8 +16,6 @@ package limited_support
 import (
 	"context"
 	"fmt"
-	"os"
-
 	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -35,8 +33,6 @@ const (
 	limitedSupportConfigMapNamespace = "openshift-osd-metrics"
 )
 
-const EnvClusterID = "CLUSTER_ID"
-
 var log = logf.Log.WithName("controller_limited_support")
 
 // LimitedSupportConfigMapReconciler reconciles a ConfigMap object
@@ -44,6 +40,7 @@ type LimitedSupportConfigMapReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
 	MetricsAggregator *metrics.AdoptionMetricsAggregator
+	ClusterId         string
 }
 
 // Reconcile reads that state of the cluster for a ConfigMap object limited-support and makes changes based the contained data
@@ -52,10 +49,6 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 	reqLogger.Info("Reconciling Limited Support ConfigMap")
 
 	// Fetch the ConfigMap openshift-osd-metrics/limited-support
-	uuid, ok := os.LookupEnv(EnvClusterID)
-	if !ok || uuid == "" {
-		return ctrl.Result{}, fmt.Errorf("cluster ID unset or returned as empty string")
-	}
 	cfgMap := &corev1.ConfigMap{}
 	ns := limitedSupportConfigMapNamespace
 	err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: limitedSupportConfigMapName}, cfgMap)
@@ -65,14 +58,14 @@ func (r *LimitedSupportConfigMapReconciler) Reconcile(ctx context.Context, req c
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
 			reqLogger.Info(fmt.Sprintf("Did not find ConfigMap %v", limitedSupportConfigMapName))
-			r.MetricsAggregator.SetLimitedSupport(uuid, false)
+			r.MetricsAggregator.SetLimitedSupport(r.ClusterId, false)
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
 	reqLogger.Info(fmt.Sprintf("Found ConfigMap %v", limitedSupportConfigMapName))
-	r.MetricsAggregator.SetLimitedSupport(uuid, true)
+	r.MetricsAggregator.SetLimitedSupport(r.ClusterId, true)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/limited_support/limited_support_controller_test.go
+++ b/controllers/limited_support/limited_support_controller_test.go
@@ -26,13 +26,13 @@ func makeTestConfigMap(name string, namespace string) *corev1.ConfigMap {
 
 func TestReconcileLimitedSupportConfigMap_Reconcile(t *testing.T) {
 	for _, tc := range []struct {
-		name             string
-		expectedResults  string
-		testEnvClusterID string
+		name            string
+		expectedResults string
+		clusterId       string
 	}{
 		{
-			name:             "limited-support correct ConfigMap",
-			testEnvClusterID: "i-am-a-cluster-id",
+			name:      "limited-support correct ConfigMap",
+			clusterId: "i-am-a-cluster-id",
 			expectedResults: `
 # HELP limited_support_enabled Indicates if limited support is enabled
 # TYPE limited_support_enabled gauge
@@ -41,8 +41,7 @@ limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 1
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(EnvClusterID, tc.testEnvClusterID)
-			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
+			metricsAggregator := metrics.NewMetricsAggregator(time.Second, tc.clusterId)
 			done := metricsAggregator.Run()
 			defer close(done)
 			err := corev1.AddToScheme(scheme.Scheme)
@@ -53,6 +52,7 @@ limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 1
 			reconciler := LimitedSupportConfigMapReconciler{
 				Client:            fakeClient,
 				MetricsAggregator: metricsAggregator,
+				ClusterId:         tc.clusterId,
 			}
 			result, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
@@ -75,13 +75,13 @@ limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 1
 	}
 
 	for _, tc := range []struct {
-		name             string
-		expectedResults  string
-		testEnvClusterID string
+		name            string
+		expectedResults string
+		clusterId       string
 	}{
 		{
-			name:             "limited-support invalid configMap",
-			testEnvClusterID: "i-am-a-cluster-id",
+			name:      "limited-support invalid configMap",
+			clusterId: "i-am-a-cluster-id",
 			expectedResults: `
 # HELP limited_support_enabled Indicates if limited support is enabled
 # TYPE limited_support_enabled gauge
@@ -90,8 +90,7 @@ limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 0
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(EnvClusterID, tc.testEnvClusterID)
-			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
+			metricsAggregator := metrics.NewMetricsAggregator(time.Second, tc.clusterId)
 			done := metricsAggregator.Run()
 			defer close(done)
 			err := corev1.AddToScheme(scheme.Scheme)
@@ -102,6 +101,7 @@ limited_support_enabled{_id="i-am-a-cluster-id",name="osd_exporter"} 0
 			reconciler := LimitedSupportConfigMapReconciler{
 				Client:            fakeClient,
 				MetricsAggregator: metricsAggregator,
+				ClusterId:         tc.clusterId,
 			}
 			result, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 				NamespacedName: types.NamespacedName{

--- a/controllers/oauth/oauth_controller_test.go
+++ b/controllers/oauth/oauth_controller_test.go
@@ -90,7 +90,7 @@ func TestReconcileOAuth_Reconcile(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			metricsAggregator := metrics.NewMetricsAggregator(time.Second)
+			metricsAggregator := metrics.NewMetricsAggregator(time.Second, "cluster-id")
 			done := metricsAggregator.Run()
 			defer close(done)
 			err := configv1.Install(scheme.Scheme)

--- a/controllers/proxy/proxy_controller.go
+++ b/controllers/proxy/proxy_controller.go
@@ -15,9 +15,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
-	"os"
-
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,18 +22,16 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var log = logf.Log.WithName("controller_proxy")
-
-const EnvClusterID = "CLUSTER_ID"
 
 // ProxyReconciler reconciles a Proxy object
 type ProxyReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
 	MetricsAggregator *metrics.AdoptionMetricsAggregator
+	ClusterId         string
 }
 
 // Reconcile reads that state of the cluster for a Proxy object and makes changes based on the state read
@@ -49,11 +44,7 @@ func (r *ProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling Proxy")
 
-	uuid := os.Getenv(EnvClusterID)
-	if uuid == "" {
-		return reconcile.Result{}, fmt.Errorf("cluster ID returned as empty string")
-	}
-	r.MetricsAggregator.SetClusterID(uuid)
+	r.MetricsAggregator.SetClusterID(r.ClusterId)
 
 	// Fetch the Proxy instance
 	instance := &configv1.Proxy{}

--- a/controllers/proxy/proxy_controller_test.go
+++ b/controllers/proxy/proxy_controller_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
-	openshiftapi "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,39 +36,38 @@ const (
 	testNamespace = "test"
 )
 
-func makeTestProxy(name, namespace string, proxySpec openshiftapi.ProxySpec, proxyStatus openshiftapi.ProxyStatus) *openshiftapi.Proxy {
-	proxy := &openshiftapi.Proxy{
+func makeTestProxy(name, namespace string, proxySpec configv1.ProxySpec, proxyStatus configv1.ProxyStatus) *configv1.Proxy {
+	proxy := &configv1.Proxy{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec:       proxySpec,
 		Status:     proxyStatus,
 	}
 	return proxy
 }
+
 func TestReconcileProxy_Reconcile(t *testing.T) {
 	for _, tc := range []struct {
 		name                     string
-		proxyStatus              openshiftapi.ProxyStatus
-		proxySpec                openshiftapi.ProxySpec
-		clusterId                string
+		proxyStatus              configv1.ProxyStatus
+		proxySpec                configv1.ProxySpec
 		expectedClusterIDResults string
 		expectedProxyResults     string
 	}{
 		{
-			name: "with ca and cluster id environment non empty string",
-			proxySpec: openshiftapi.ProxySpec{
-				TrustedCA: openshiftapi.ConfigMapNameReference{
+			name: "with ca",
+			proxySpec: configv1.ProxySpec{
+				TrustedCA: configv1.ConfigMapNameReference{
 					Name: "test",
 				},
 			},
-			proxyStatus: openshiftapi.ProxyStatus{
+			proxyStatus: configv1.ProxyStatus{
 				HTTPProxy:  "http://example.com",
 				HTTPSProxy: "https://example.com",
 			},
-			clusterId: "i-am-a-cluster-id",
 			expectedClusterIDResults: `
 # HELP cluster_id Indicates the cluster id
 # TYPE cluster_id gauge
-cluster_id{_id="i-am-a-cluster-id",name="osd_exporter"} 1
+cluster_id{_id="cluster-id",name="osd_exporter"} 1
 	`,
 			expectedProxyResults: `
 # HELP cluster_proxy Indicates cluster proxy state
@@ -77,17 +76,16 @@ cluster_proxy{http="1",https="1",name="osd_exporter",trusted_ca="1"} 1
 `,
 		},
 		{
-			name:      "no ca and cluster id environment non empty string",
-			proxySpec: openshiftapi.ProxySpec{},
-			proxyStatus: openshiftapi.ProxyStatus{
+			name:      "no ca",
+			proxySpec: configv1.ProxySpec{},
+			proxyStatus: configv1.ProxyStatus{
 				HTTPProxy:  "http://example.com",
 				HTTPSProxy: "https://example.com",
 			},
-			clusterId: "i-am-a-cluster-id",
 			expectedClusterIDResults: `
 # HELP cluster_id Indicates the cluster id
 # TYPE cluster_id gauge
-cluster_id{_id="i-am-a-cluster-id",name="osd_exporter"} 1
+cluster_id{_id="cluster-id",name="osd_exporter"} 1
 	`,
 			expectedProxyResults: `
 # HELP cluster_proxy Indicates cluster proxy state
@@ -97,17 +95,17 @@ cluster_proxy{http="1",https="1",name="osd_exporter",trusted_ca="0"} 1
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			metricsAggregator := metrics.NewMetricsAggregator(time.Second, tc.clusterId)
+			metricsAggregator := metrics.NewMetricsAggregator(time.Second, "cluster-id")
 			done := metricsAggregator.Run()
 			defer close(done)
-			err := openshiftapi.Install(scheme.Scheme)
+			err := configv1.Install(scheme.Scheme)
 			require.NoError(t, err)
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(makeTestProxy(testName, testNamespace, tc.proxySpec, tc.proxyStatus)).Build()
 			reconciler := ProxyReconciler{
 				Client:            fakeClient,
 				MetricsAggregator: metricsAggregator,
-				ClusterId:         tc.clusterId,
+				ClusterId:         "cluster-id",
 			}
 			result, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
@@ -121,7 +119,7 @@ cluster_proxy{http="1",https="1",name="osd_exporter",trusted_ca="0"} 1
 			time.Sleep(time.Second * 3)
 			require.NoError(t, err)
 			require.NotNil(t, result)
-			var testProxy openshiftapi.Proxy
+			var testProxy configv1.Proxy
 			err = fakeClient.Get(context.Background(), types.NamespacedName{Name: testName, Namespace: testNamespace}, &testProxy)
 			require.NoError(t, err)
 
@@ -132,59 +130,6 @@ cluster_proxy{http="1",https="1",name="osd_exporter",trusted_ca="0"} 1
 			metric = metricsAggregator.GetClusterProxyMetric()
 			err = testutil.CollectAndCompare(metric, strings.NewReader(tc.expectedProxyResults))
 			require.NoError(t, err)
-		})
-	}
-}
-
-func TestReconcileProxy_ReconcileError(t *testing.T) {
-	for _, tc := range []struct {
-		name                     string
-		proxyStatus              openshiftapi.ProxyStatus
-		proxySpec                openshiftapi.ProxySpec
-		clusterId                string
-		expectedClusterIDResults string
-		expectedProxyResults     string
-	}{
-		{
-			name:      "no ca and cluster id env variable is empty string",
-			proxySpec: openshiftapi.ProxySpec{},
-			proxyStatus: openshiftapi.ProxyStatus{
-				HTTPProxy:  "http://example.com",
-				HTTPSProxy: "https://example.com",
-			},
-			clusterId: "",
-			expectedClusterIDResults: `
-# HELP cluster_id Indicates the cluster id
-# TYPE cluster_id gauge
-cluster_id{_id="",name="osd_exporter"} 1
-	`,
-			expectedProxyResults: `
-# HELP cluster_proxy Indicates cluster proxy state
-# TYPE cluster_proxy gauge
-cluster_proxy{http="1",https="1",name="osd_exporter",trusted_ca="0"} 1
-`,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			metricsAggregator := metrics.NewMetricsAggregator(time.Second, tc.clusterId)
-			done := metricsAggregator.Run()
-			defer close(done)
-			err := openshiftapi.Install(scheme.Scheme)
-			require.NoError(t, err)
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(makeTestProxy(testName, testNamespace, tc.proxySpec, tc.proxyStatus)).Build()
-			reconciler := ProxyReconciler{
-				Client:            fakeClient,
-				MetricsAggregator: metricsAggregator,
-				ClusterId:         tc.clusterId,
-			}
-			_, err = reconciler.Reconcile(context.TODO(), ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Namespace: testNamespace,
-					Name:      testName,
-				},
-			})
-			require.Error(t, err)
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"os"
 
@@ -102,10 +103,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("exporting cluster id to container env")
+	setupLog.Info("retrieving cluster id")
 	clusterId, err := getClusterID(mgr.GetAPIReader())
 	if err != nil {
-		setupLog.Error(err, "Failed to retrieve and export ClusterID")
+		setupLog.Error(err, "Failed to retrieve")
 		os.Exit(1)
 	}
 
@@ -120,7 +121,7 @@ func main() {
 	if err = (&configmap.ConfigMapReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		MetricsAggregator: metrics.GetMetricsAggregator(),
+		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Configmap")
 		os.Exit(1)
@@ -129,7 +130,7 @@ func main() {
 	if err = (&group.GroupReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		MetricsAggregator: metrics.GetMetricsAggregator(),
+		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Group")
 		os.Exit(1)
@@ -138,7 +139,7 @@ func main() {
 	if err = (&limited_support.LimitedSupportConfigMapReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		MetricsAggregator: metrics.GetMetricsAggregator(),
+		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
 		ClusterId:         clusterId,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Limited Support")
@@ -148,7 +149,7 @@ func main() {
 	if err = (&oauth.OAuthReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		MetricsAggregator: metrics.GetMetricsAggregator(),
+		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OAuth")
 		os.Exit(1)
@@ -157,7 +158,7 @@ func main() {
 	if err = (&proxy.ProxyReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		MetricsAggregator: metrics.GetMetricsAggregator(),
+		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
 		ClusterId:         clusterId,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Proxy")
@@ -174,14 +175,14 @@ func main() {
 	}
 
 	// Setup metrics collector
-	collector := metrics.GetMetricsAggregator()
+	collector := metrics.GetMetricsAggregator(clusterId)
 	done := collector.Run()
 	defer close(done)
 	metricsConfig := customMetrics.NewBuilder(operatorConfig.OperatorNamespace, operatorConfig.OperatorName).
 		WithPath("/metrics").
 		WithPort(metricsPort).
 		WithServiceMonitor().
-		WithCollectors(metrics.GetMetricsAggregator().GetMetrics()).
+		WithCollectors(metrics.GetMetricsAggregator(clusterId).GetMetrics()).
 		GetConfig()
 	if err = customMetrics.ConfigureMetrics(context.TODO(), *metricsConfig); err != nil {
 		setupLog.Error(err, "Failed to run metrics server")
@@ -199,6 +200,10 @@ func getClusterID(client client.Reader) (string, error) {
 	cv := &configv1.ClusterVersion{}
 	if err := client.Get(context.TODO(), types.NamespacedName{Name: "version"}, cv); err != nil {
 		return "", err
+	}
+
+	if string(cv.Spec.ClusterID) == "" {
+		return "", errors.New("got empty string for cluster id from the ClusterVersion custom resource")
 	}
 
 	return string(cv.Spec.ClusterID), nil

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -163,10 +163,8 @@ func (a *AdoptionMetricsAggregator) SetLimitedSupport(uuid string, enabled bool)
 
 	if enabled {
 		a.limitedSupport.With(labels).Set(1)
-
 	} else {
 		a.limitedSupport.With(labels).Set(0)
-
 	}
 }
 

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"os"
 	"sync"
 	"time"
 
@@ -50,7 +49,7 @@ type AdoptionMetricsAggregator struct {
 }
 
 // NewMetricsAggregator creates a metric aggregator. Should not be used directory but through GetMetricsAggregator
-func NewMetricsAggregator(aggregationInterval time.Duration) *AdoptionMetricsAggregator {
+func NewMetricsAggregator(aggregationInterval time.Duration, clusterId string) *AdoptionMetricsAggregator {
 	collector := &AdoptionMetricsAggregator{
 		identityProviders: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "identity_provider",
@@ -91,8 +90,7 @@ func NewMetricsAggregator(aggregationInterval time.Duration) *AdoptionMetricsAgg
 		aggregationInterval: aggregationInterval,
 	}
 	collector.clusterAdmin.Set(0)
-	uuid := os.Getenv("CLUSTER_ID")
-	collector.SetLimitedSupport(uuid, false)
+	collector.SetLimitedSupport(clusterId, false)
 	return collector
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -10,9 +10,9 @@ var (
 	aggregator *AdoptionMetricsAggregator
 )
 
-func GetMetricsAggregator() *AdoptionMetricsAggregator {
+func GetMetricsAggregator(clusterId string) *AdoptionMetricsAggregator {
 	if aggregator == nil {
-		aggregator = NewMetricsAggregator(aggregatorResyncInterval)
+		aggregator = NewMetricsAggregator(aggregatorResyncInterval, clusterId)
 	}
 	return aggregator
 }


### PR DESCRIPTION
[OSD-14250](https://issues.redhat.com//browse/OSD-14250)

> In the past, osd-metrics-exporter exported an environment variable containing the cluster-id on startup, then the controllers that needed the cluster id would implement their own logic to read the environment variable. We should instead pass it explicitly to the controllers that need it so that the dependency is clear as controllers can otherwise fail silently if the environment variable is incorrectly set or unset.

Previously we have been setting and reading the `CLUSTER_ID` variable everywhere