### PR TITLE
Adding  cluster ID as label _id in metrics to cluster admin, cluster proxy, cluster proxy CA

### DIFF
--- a/controllers/group/group_controller.go
+++ b/controllers/group/group_controller.go
@@ -41,6 +41,7 @@ type GroupReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
 	MetricsAggregator *metrics.AdoptionMetricsAggregator
+	ClusterId         string
 }
 
 // Reconcile reads that state of the cluster for a Group object and makes changes based on the state read
@@ -69,9 +70,9 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				return ctrl.Result{}, err
 			}
 		}
-		r.MetricsAggregator.SetClusterAdmin(len(group.Users) > 0)
+		r.MetricsAggregator.SetClusterAdmin(r.ClusterId, len(group.Users) > 0)
 	} else {
-		r.MetricsAggregator.SetClusterAdmin(false)
+		r.MetricsAggregator.SetClusterAdmin(r.ClusterId, false)
 		if utils.ContainsString(group.Finalizers, finalizer) {
 			controllerutil.RemoveFinalizer(group, finalizer)
 			if err := r.Client.Update(ctx, group); err != nil {

--- a/controllers/group/group_controller_test.go
+++ b/controllers/group/group_controller_test.go
@@ -19,10 +19,11 @@ import (
 
 func TestReconcileGroup_Reconcile(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		users  []string
-		result int
-		delete bool
+		name      string
+		users     []string
+		result    int
+		delete    bool
+		clusterId string
 	}{
 		{
 			name:   "empty cluster-admins group",
@@ -54,7 +55,7 @@ func TestReconcileGroup_Reconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(group).Build()
 			reconcileGroup := &GroupReconciler{
 				Client:            fakeClient,
-				MetricsAggregator: metrics.NewMetricsAggregator(time.Second*10, "cluster-id"),
+				MetricsAggregator: metrics.NewMetricsAggregator(time.Second*10, tc.clusterId),
 			}
 			_, err = reconcileGroup.Reconcile(context.TODO(), ctrl.Request{
 				NamespacedName: types.NamespacedName{Name: clusterAdminGroupName},

--- a/controllers/proxy/proxy_controller.go
+++ b/controllers/proxy/proxy_controller.go
@@ -15,6 +15,7 @@ package proxy
 
 import (
 	"context"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -79,7 +80,7 @@ func (r *ProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		proxyTrustedCA = "1"
 	}
 	// aggregate metrics
-	r.MetricsAggregator.SetClusterProxy(proxyHTTP, proxyHTTPS, proxyTrustedCA, proxyEnabled)
+	r.MetricsAggregator.SetClusterProxy(r.ClusterId, proxyHTTP, proxyHTTPS, proxyTrustedCA, proxyEnabled)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/proxy/proxy_controller_test.go
+++ b/controllers/proxy/proxy_controller_test.go
@@ -72,7 +72,7 @@ cluster_id{_id="cluster-id",name="osd_exporter"} 1
 			expectedProxyResults: `
 # HELP cluster_proxy Indicates cluster proxy state
 # TYPE cluster_proxy gauge
-cluster_proxy{http="1",https="1",name="osd_exporter",trusted_ca="1"} 1
+cluster_proxy{_id="cluster-id",http="1",https="1",name="osd_exporter",trusted_ca="1"} 1
 `,
 		},
 		{
@@ -90,7 +90,7 @@ cluster_id{_id="cluster-id",name="osd_exporter"} 1
 			expectedProxyResults: `
 # HELP cluster_proxy Indicates cluster proxy state
 # TYPE cluster_proxy gauge
-cluster_proxy{http="1",https="1",name="osd_exporter",trusted_ca="0"} 1
+cluster_proxy{_id="cluster-id",http="1",https="1",name="osd_exporter",trusted_ca="0"} 1
 `,
 		},
 	} {

--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
+		ClusterId:         clusterId,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Configmap")
 		os.Exit(1)
@@ -131,6 +132,7 @@ func main() {
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
 		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
+		ClusterId:         clusterId,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Group")
 		os.Exit(1)

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -37,12 +37,12 @@ type providerKey struct {
 
 type AdoptionMetricsAggregator struct {
 	identityProviders    *prometheus.GaugeVec
-	clusterAdmin         prometheus.Gauge
+	clusterAdmin         prometheus.GaugeVec
 	limitedSupport       *prometheus.GaugeVec
 	providerMap          map[providerKey][]configv1.IdentityProviderType
 	clusterProxy         *prometheus.GaugeVec
 	clusterProxyCAExpiry *prometheus.GaugeVec
-	clusterProxyCAValid  prometheus.Gauge
+	clusterProxyCAValid  prometheus.GaugeVec
 	clusterID            *prometheus.GaugeVec
 	mutex                sync.Mutex
 	aggregationInterval  time.Duration
@@ -56,11 +56,11 @@ func NewMetricsAggregator(aggregationInterval time.Duration, clusterId string) *
 			Help:        "Indicates if an identity provider is enabled",
 			ConstLabels: map[string]string{"name": osdExporterValue},
 		}, []string{providerLabel}),
-		clusterAdmin: prometheus.NewGauge(prometheus.GaugeOpts{
+		clusterAdmin: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "cluster_admin_enabled",
 			Help:        "Indicates if the cluster-admin role is enabled",
 			ConstLabels: map[string]string{"name": osdExporterValue},
-		}),
+		}, []string{clusterIDLabel}),
 		limitedSupport: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "limited_support_enabled",
 			Help:        "Indicates if limited support is enabled",
@@ -70,17 +70,17 @@ func NewMetricsAggregator(aggregationInterval time.Duration, clusterId string) *
 			Name:        "cluster_proxy",
 			Help:        "Indicates cluster proxy state",
 			ConstLabels: map[string]string{"name": osdExporterValue},
-		}, []string{proxyHTTPLabel, proxyHTTPSLabel, proxyCALabel}),
+		}, []string{clusterIDLabel, proxyHTTPLabel, proxyHTTPSLabel, proxyCALabel}),
 		clusterProxyCAExpiry: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "cluster_proxy_ca_expiry_timestamp",
 			Help:        "Indicates cluster proxy CA expiry unix timestamp in UTC",
 			ConstLabels: map[string]string{"name": osdExporterValue},
-		}, []string{proxyCASubjectLabel}),
-		clusterProxyCAValid: prometheus.NewGauge(prometheus.GaugeOpts{
+		}, []string{clusterIDLabel, proxyCASubjectLabel}),
+		clusterProxyCAValid: *prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "cluster_proxy_ca_valid",
 			Help:        "Indicates if cluster proxy CA valid",
 			ConstLabels: map[string]string{"name": osdExporterValue},
-		}),
+		}, []string{clusterIDLabel}),
 		clusterID: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name:        "cluster_id",
 			Help:        "Indicates the cluster id",
@@ -89,7 +89,7 @@ func NewMetricsAggregator(aggregationInterval time.Duration, clusterId string) *
 		providerMap:         make(map[providerKey][]configv1.IdentityProviderType),
 		aggregationInterval: aggregationInterval,
 	}
-	collector.clusterAdmin.Set(0)
+	collector.SetClusterAdmin(clusterId, false)
 	collector.SetLimitedSupport(clusterId, false)
 	return collector
 }
@@ -148,11 +148,14 @@ func (a *AdoptionMetricsAggregator) aggregate() {
 	}
 }
 
-func (a *AdoptionMetricsAggregator) SetClusterAdmin(enabled bool) {
+func (a *AdoptionMetricsAggregator) SetClusterAdmin(uuid string, enabled bool) {
+	labels := prometheus.Labels{
+		clusterIDLabel: uuid,
+	}
 	if enabled {
-		a.clusterAdmin.Set(1)
+		a.clusterAdmin.With(labels).Set(1)
 	} else {
-		a.clusterAdmin.Set(0)
+		a.clusterAdmin.With(labels).Set(0)
 	}
 }
 
@@ -168,25 +171,30 @@ func (a *AdoptionMetricsAggregator) SetLimitedSupport(uuid string, enabled bool)
 	}
 }
 
-func (a *AdoptionMetricsAggregator) SetClusterProxy(proxyHTTP string, proxyHTTPS string, proxyTrustedCA string, proxyEnabled int) {
+func (a *AdoptionMetricsAggregator) SetClusterProxy(uuid string, proxyHTTP string, proxyHTTPS string, proxyTrustedCA string, proxyEnabled int) {
 	a.clusterProxy.With(prometheus.Labels{
+		clusterIDLabel:  uuid,
 		proxyHTTPLabel:  proxyHTTP,
 		proxyHTTPSLabel: proxyHTTPS,
 		proxyCALabel:    proxyTrustedCA,
 	}).Set(float64(proxyEnabled))
 }
 
-func (a *AdoptionMetricsAggregator) SetClusterProxyCAExpiry(subject string, clusterProxyCAExpiry int64) {
+func (a *AdoptionMetricsAggregator) SetClusterProxyCAExpiry(uuid string, subject string, clusterProxyCAExpiry int64) {
 	a.clusterProxyCAExpiry.With(prometheus.Labels{
+		clusterIDLabel:      uuid,
 		proxyCASubjectLabel: subject,
 	}).Set(float64(clusterProxyCAExpiry))
 }
 
-func (a *AdoptionMetricsAggregator) SetClusterProxyCAValid(valid bool) {
+func (a *AdoptionMetricsAggregator) SetClusterProxyCAValid(uuid string, valid bool) {
+	labels := prometheus.Labels{
+		clusterIDLabel: uuid,
+	}
 	if valid {
-		a.clusterProxyCAValid.Set(1)
+		a.clusterProxyCAValid.With(labels).Set(1)
 	} else {
-		a.clusterProxyCAValid.Set(0)
+		a.clusterProxyCAValid.With(labels).Set(0)
 	}
 }
 
@@ -200,7 +208,7 @@ func (a *AdoptionMetricsAggregator) GetMetrics() []prometheus.Collector {
 	return []prometheus.Collector{a.identityProviders, a.clusterAdmin, a.limitedSupport, a.clusterProxy, a.clusterProxyCAExpiry, a.clusterProxyCAValid, a.clusterID}
 }
 
-func (a *AdoptionMetricsAggregator) GetClusterRoleMetric() prometheus.Gauge {
+func (a *AdoptionMetricsAggregator) GetClusterRoleMetric() prometheus.GaugeVec {
 	return a.clusterAdmin
 }
 
@@ -224,6 +232,6 @@ func (a *AdoptionMetricsAggregator) GetClusterProxyCAExpiryMetrics() *prometheus
 	return a.clusterProxyCAExpiry
 }
 
-func (a *AdoptionMetricsAggregator) GetClusterProxyCAValidMetrics() prometheus.Gauge {
+func (a *AdoptionMetricsAggregator) GetClusterProxyCAValidMetrics() prometheus.GaugeVec {
 	return a.clusterProxyCAValid
 }


### PR DESCRIPTION
This PR is part of the [OSD-14250](https://issues.redhat.com/browse/OSD-14250) ticket. The purpose of this PR is to add _id label to cluster admin, cluster proxy, cluster proxy CA expiry Timestamp, cluster proxy ca valid and cluster id.