### PR TITLE
[AUTH-388] set pod security admission labels for namespace

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -3,7 +3,7 @@ ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7-6
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-1
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -36,6 +36,9 @@ objects:
             name: openshift-osd-metrics
             labels:
               openshift.io/cluster-monitoring: 'true'
+              pod-security.kubernetes.io/enforce: 'baseline'
+              pod-security.kubernetes.io/audit: 'baseline'
+              pod-security.kubernetes.io/warn: 'baseline'
         - apiVersion: rbac.authorization.k8s.io/v1
           kind: Role
           metadata:


### PR DESCRIPTION
This sets pod security admission labels. Currently, none are set and starting with OpenShift 4.13 this generates warnings in Telemetry. This fixes it.

Refer to https://kubernetes.io/docs/concepts/security/pod-security-standards/ to further tighten the labels potentially to the recommended `restricted` level.

The labels were determined by using the https://github.com/stlaz/psachecker tool.