### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -3,7 +3,7 @@ ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7-6
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8-1
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -92,6 +92,8 @@ objects:
               mediatype: ''
             publisher: Red Hat
             sourceType: grpc
+            grpcPodConfig:
+              securityContextConfig: restricted
         - apiVersion: operators.coreos.com/v1alpha1
           kind: Subscription
           metadata:


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: [OSD-15619](https://issues.redhat.com//browse/OSD-15619)