### PR TITLE
[WIP] publish customer pod/pdb preventing drain metrics

### DIFF
--- a/controllers/machine/machine_controller.go
+++ b/controllers/machine/machine_controller.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	machinev1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	"github.com/openshift/osd-metrics-exporter/pkg/metrics"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	machineNamespace = "openshift-machine-api"
+)
+
+var log = logf.Log.WithName("controller_machine")
+
+// MachineReconciler reconciles a Machine object
+type MachineReconciler struct {
+	client.Client
+	Scheme            *runtime.Scheme
+	MetricsAggregator *metrics.AdoptionMetricsAggregator
+	ClusterId         string
+}
+
+// Reconcile reads that state of the cluster for machine objects and makes changes based the contained data
+func (r *MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
+	reqLogger.Info("Reconciling Machines")
+
+	// Fetch the machines in openshift-machine-api
+	machines := &machinev1beta1.Machine{}
+	err := r.Client.List(ctx, machines, &client.ListOptions{Namespace: machineNamespace})
+	if err != nil {
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+	reqLogger.Info(fmt.Sprintf("Found Machines"))
+	// r.MetricsAggregator.DoSomething(r.ClusterId, true)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&machinev1beta1.Machine{}).
+		Complete(r)
+}

--- a/deploy/10_osd-metrics-exporter.ClusterRole.yaml
+++ b/deploy/10_osd-metrics-exporter.ClusterRole.yaml
@@ -41,3 +41,11 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - machine.openshift.io
+    resources:
+      - machines
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
part of https://issues.redhat.com/browse/OSD-18411

this is an attempt to automate SL notification for the KubeNodeUnschedulable alert, in case the alert is firing while customer workloads are preventing the node from draining.

the implementation comes from this SOP: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md

this PR will expose 2 new metrics:
- `customer_pod_preventing_drain`
- `customer_pdb_preventing_drain`

these metrics will be used to decide if a `KubeNodeUnschedulable` should be routed to a SL or to SRE: https://github.com/openshift/managed-cluster-config/pull/1827
