### PR TITLE
test fix: uses the same env var name as provided by osde2e pod runner

### DIFF
--- a/osde2e/osd_metrics_exporter_tests.go
+++ b/osde2e/osd_metrics_exporter_tests.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("osd-metrics-exporter", ginkgo.Ordered, func() {
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		log.SetLogger(ginkgo.GinkgoLogr)
 
-		clusterID = os.Getenv("CLUSTER_ID")
+		clusterID = os.Getenv("OCM_CLUSTER_ID")
 		Expect(clusterID).ShouldNot(BeEmpty(), "failed to find CLUSTER_ID environment variable")
 
 		var err error


### PR DESCRIPTION
Test fix: 

e2e test is failing as it's using incorrect env var name.

[SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)

