### PR TITLE
Fixes new MachineController issues

### DIFF
--- a/controllers/machine/machine_controller.go
+++ b/controllers/machine/machine_controller.go
@@ -218,7 +218,7 @@ func (r *MachineReconciler) evaluateDeletingMachine(ctx context.Context, machine
 	}
 
 	// Make sure this event is happening _after_ the machine deletion and it's not a pre-existing event
-	if machine.DeletionTimestamp.Time.Before(event.LastTimestamp.Time) {
+	if machine.DeletionTimestamp.Time.After(event.LastTimestamp.Time) {
 		reqLogger.Info("Latest event was before machine was deleted, requeueing")
 		return utils.RequeueAfter(defaultDelayInterval)
 	}

--- a/deploy/20_osd-metrics-exporter_openshift-machine-api.RoleBinding.yaml
+++ b/deploy/20_osd-metrics-exporter_openshift-machine-api.RoleBinding.yaml
@@ -1,0 +1,15 @@
+# Allow the operator to manage resources in its own namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-metrics-exporter
+  namespace: openshift-machine-api
+subjects:
+  - kind: ServiceAccount
+    name: osd-metrics-exporter
+    namespace: openshift-osd-metrics
+roleRef:
+  kind: Role
+  name: osd-metrics-exporter
+  apiGroup: rbac.authorization.k8s.io
+


### PR DESCRIPTION
Fixes the following:

* Incorrect permissions due to an incorrectly formatted RoleBinding causing osd-metrics-exporter to crashloop - Resolves [OSD-19494](https://issues.redhat.com//browse/OSD-19494)
* Fixes logic making sure that machine deletion timestamp is actually before the last timestamp of the event - Resolves [OSD-18411](https://issues.redhat.com//browse/OSD-18411)