### PR TITLE
fix e2e test - min passwd length is 14 now

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . /osd-metrics-exporter
 WORKDIR /osd-metrics-exporter
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1697626218
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 ENV OPERATOR=/usr/local/bin/osd-metrics-exporter \
     USER_UID=1001 \
     USER_NAME=osd-metrics-exporter

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1697626218
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/osde2e/osd_metrics_exporter_tests.go
+++ b/osde2e/osd_metrics_exporter_tests.go
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("osd-metrics-exporter", ginkgo.Ordered, func() {
 		result := results[0].Value
 		Expect(int(result)).Should(BeNumerically("==", 1), "prometheus exporter is not healthy")
 
-		user := clustersmgmtv1.NewHTPasswdIdentityProvider().Username(rand.String(10)).Password(rand.String(10))
+		user := clustersmgmtv1.NewHTPasswdIdentityProvider().Username(rand.String(14)).Password(rand.String(14))
 		idp, err := clustersmgmtv1.NewIdentityProvider().Htpasswd(user).Type(clustersmgmtv1.IdentityProviderTypeHtpasswd).Name("osde2e").Build()
 		Expect(err).ShouldNot(HaveOccurred(), "unable to build htpasswd IDP object")
 


### PR DESCRIPTION
fix e2e test newly erroring as length of password is 14 now. 

`
{failed to create htpasswd IDP for cluster
Unexpected error:
    <*errors.Error | 0xc000331650>: 
    status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is 'b441591c-dd9f-418b-a02f-a2d2be71489a': invalid password for user 'vn7pt6tdd5': Password must be at least 14 characters (got 10)
    {
        bitmap_: 63,
        status: 400,
        id: "400",
        href: "/api/clusters_mgmt/v1/errors/400",
        code: "CLUSTERS-MGMT-400",
        reason: "invalid password for user 'vn7pt6tdd5': Password must be at least 14 characters (got 10)",
        details: nil,
        operationID: "b441591c-dd9f-418b-a02f-a2d2be71489a",
    }
occurred failed [FAILED] failed to create htpasswd IDP for cluster
`


last prow test https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-rosa-stage-complete-e2e/1726148546190643200 