### PR TITLE
SDCICD-1178: remove unknown fields from olm artifacts

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -74,18 +74,6 @@ objects:
             namespace: openshift-osd-metrics
           spec:
             image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-            affinity:
-              nodeAffinity:
-                preferredDuringSchedulingIgnoredDuringExecution:
-                  - preference:
-                      matchExpressions:
-                        - key: node-role.kubernetes.io/infra
-                          operator: Exists
-                    weight: 1
-            tolerations:
-              - effect: NoSchedule
-                key: node-role.kubernetes.io/infra
-                operator: Exists
             displayName: OSD Metrics Exporter
             icon:
               base64data: ''
@@ -132,7 +120,6 @@ objects:
           roleRef:
             kind: Role
             name: osd-metrics-exporter-watch-configmaps
-            namespace: openshift-config
             apiGroup: rbac.authorization.k8s.io
         - kind: Role
           apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
CatalogSource does not define `affinity` or `toleration` fields in the
spec. Also remove the `namespace` from the RoleBinding.roleRef

```
2023-12-18T08:04:00Z	INFO	controllers.ObjectSet	API status error with empty reason string	{"ObjectSet": "/managed-openshift-release-bundle-5f548cb8bb", "err": {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"failed to create typed patch object (openshift-osd-metrics/osd-metrics-exporter-registry; operators.coreos.com/v1alpha1, Kind=CatalogSource): .spec.tolerations: field not declared in schema","code":500}}
2023-12-18T08:04:00Z	INFO	controllers.ObjectSet	API status error with empty reason string	{"ObjectSet": "/managed-openshift-release-bundle-5f548cb8bb", "err": {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"failed to create typed patch object (openshift-config/osd-metrics-exporter-watch-configmaps; rbac.authorization.k8s.io/v1, Kind=RoleBinding): .roleRef.namespace: field not declared in schema","code":500}}
```

https://docs.openshift.com/container-platform/4.14/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.html

https://issues.redhat.com/browse/SDCICD-1178

Signed-off-by: Brady Pratt <bpratt@redhat.com>
