### PR TITLE
Remove namespace from promql query.

### DIFF
--- a/osde2e/osd_metrics_exporter_tests.go
+++ b/osde2e/osd_metrics_exporter_tests.go
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("osd-metrics-exporter", ginkgo.Ordered, func() {
 		ginkgo.DeferCleanup(idpClient.IdentityProvider(idpAddResponse.Body().ID()).Delete().SendContext)
 
 		Eventually(ctx, func(ctx context.Context) (int, error) {
-			query := fmt.Sprintf(`identity_provider{provider="HTPasswd", name="osd_exporter", namespace=%q}`, namespace)
+			query := `identity_provider{provider="HTPasswd", name="osd_exporter"}`
 			results, err = prom.InstantQuery(ctx, query)
 			if err != nil {
 				return 0, err


### PR DESCRIPTION
This is just to check if the `namespace` label in the promql must be removed - checking a real cluster this label does not exist.