### PR TITLE
Update osde2e to generate a temporary password that meets requirements

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . /osd-metrics-exporter
 WORKDIR /osd-metrics-exporter
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 ENV OPERATOR=/usr/local/bin/osd-metrics-exporter \
     USER_UID=1001 \
     USER_NAME=osd-metrics-exporter

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,15 @@ go 1.19
 
 require (
 	github.com/google/go-cmp v0.6.0
+	github.com/onsi/ginkgo/v2 v2.9.7
+	github.com/onsi/gomega v1.27.7
+	github.com/openshift-online/ocm-sdk-go v0.1.344
 	// go get github.com/openshift/api@release-4.11
 	github.com/openshift/api v0.0.0-20230426102702-398424d53f74
 	// go get github.com/openshift/cluster-network-operator@release-4.11
 	github.com/openshift/cluster-network-operator v0.0.0-20221129140819-4cbcf0da9cb8
 	github.com/openshift/operator-custom-metrics v0.5.0
+	github.com/openshift/osde2e-common v0.0.0-20231006200548-93749af9460c
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.55.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/stretchr/testify v1.8.4
@@ -16,13 +20,6 @@ require (
 	k8s.io/apimachinery v0.27.4
 	k8s.io/client-go v0.27.4
 	sigs.k8s.io/controller-runtime v0.15.1
-)
-
-require (
-	github.com/onsi/ginkgo/v2 v2.9.7
-	github.com/onsi/gomega v1.27.7
-	github.com/openshift-online/ocm-sdk-go v0.1.344
-	github.com/openshift/osde2e-common v0.0.0-20231006200548-93749af9460c
 )
 
 require (

--- a/osde2e/osd_metrics_exporter_tests.go
+++ b/osde2e/osd_metrics_exporter_tests.go
@@ -133,12 +133,24 @@ var _ = ginkgo.Describe("osd-metrics-exporter", ginkgo.Ordered, func() {
 })
 
 // generates password to set up ocm htpasswd auth
+// Password must include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)
 func generateRandomString(length int) string {
-	var charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const (
+		lowers  = "abcdefghijklmnopqrstuvwxyz"
+		uppers  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		numbers = "0123456789"
+	)
 	var seededRand *mathrand.Rand = mathrand.New(mathrand.NewSource(time.Now().UnixNano()))
 	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
+
+	for i := 0; i < len(b)/3; i++ {
+		b[i] = lowers[seededRand.Intn(len(lowers))]
+	}
+	for i := len(b)/3 + 1; i < 2*len(b)/3; i++ {
+		b[i] = uppers[seededRand.Intn(len(uppers))]
+	}
+	for i := (2 * len(b) / 3) + 1; i < len(b); i++ {
+		b[i] = numbers[seededRand.Intn(len(numbers))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
The latest runs are failing https://testgrid.k8s.io/redhat-openshift-ocp-release-4.15-informing#periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts with

```
"failed to create htpasswd IDP for cluster\nUnexpected error:\n    <*errors.Error | 0xc000292000>: \n    status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is 'a379d3d3-fc61-4010-a8a1-d8bbd8ac5be7': invalid password for user '4hfdjpj6kp7fbq': Password must include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)\n    {\n        bitmap_: 63,\n        status: 400,\n        id: \"400\",\n        href: \"/api/clusters_mgmt/v1/errors/400\",\n        code: \"CLUSTERS-MGMT-400\",\n        reason: \"invalid password for user '4hfdjpj6kp7fbq': Password must include uppercase letters, lowercase letters, and numbers or symbols (ASCII-standard characters only)\",\n        details: nil,\n        operationID: \"a379d3d3-fc61-4010-a8a1-d8bbd8ac5be7\",\n    }\noccurred",
```

This PR aims to fix this by ensuring we generate a random temporary password with lowercase, uppercase, and numbers

[OSD-20366](https://issues.redhat.com//browse/OSD-20366)