### PR TITLE
Fix off-by-one error with random string generation

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . /osd-metrics-exporter
 WORKDIR /osd-metrics-exporter
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 ENV OPERATOR=/usr/local/bin/osd-metrics-exporter \
     USER_UID=1001 \
     USER_NAME=osd-metrics-exporter

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1108.1705420507
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/osde2e/osd_metrics_exporter_tests.go
+++ b/osde2e/osd_metrics_exporter_tests.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	mathrand "math/rand"
@@ -141,16 +142,17 @@ func generateRandomString(length int) string {
 		numbers = "0123456789"
 	)
 	var seededRand *mathrand.Rand = mathrand.New(mathrand.NewSource(time.Now().UnixNano()))
-	b := make([]byte, length)
+	var sb strings.Builder
 
-	for i := 0; i < len(b)/3; i++ {
-		b[i] = lowers[seededRand.Intn(len(lowers))]
+	for i := 0; i < length; i++ {
+		switch i % 3 {
+		case 0:
+			sb.WriteByte(lowers[seededRand.Intn(len(lowers))])
+		case 1:
+			sb.WriteByte(uppers[seededRand.Intn(len(uppers))])
+		case 2:
+			sb.WriteByte(numbers[seededRand.Intn(len(numbers))])
+		}
 	}
-	for i := len(b)/3 + 1; i < 2*len(b)/3; i++ {
-		b[i] = uppers[seededRand.Intn(len(uppers))]
-	}
-	for i := (2 * len(b) / 3) + 1; i < len(b); i++ {
-		b[i] = numbers[seededRand.Intn(len(numbers))]
-	}
-	return string(b)
+	return sb.String()
 }


### PR DESCRIPTION
[CI is failing](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts/1747849579874750464) due to:
```
status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is 'eee947d0-065b-47d8-b2cf-e99a2c53fa1a': invalid password for user 'bpngh6qg44lppf': Password must not contain special characters [�, �]
```

due to two off-by-one error in the for loops. This can also be fixed without strings.Builder, but using strings.Builder conveniently lets me ignore array indexing and helps the readability of this.

[OSD-20366](https://issues.redhat.com//browse/OSD-20366)