### PR TITLE
Add label to cpms metric indicting the instance type in cpms spec

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . /osd-metrics-exporter
 WORKDIR /osd-metrics-exporter
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1137
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161
 ENV OPERATOR=/usr/local/bin/osd-metrics-exporter \
     USER_UID=1001 \
     USER_NAME=osd-metrics-exporter

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1137
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/cpms/cpms_controller_test.go
+++ b/controllers/cpms/cpms_controller_test.go
@@ -95,7 +95,7 @@ func TestReconcileCPMS_Reconcile(t *testing.T) {
 			expectedCPMSResults: `
 # HELP cpms_enabled Indicates if the controlplanemachineset is enabled
 # TYPE cpms_enabled gauge
-cpms_enabled{_id="cluster-id",instance_type="m5.2xlarge",name="osd_exporter"} 1
+cpms_enabled{_id="cluster-id",label_beta_kubernetes_io_instance_type="m5.2xlarge",name="osd_exporter"} 1
 `,
 		},
 		{
@@ -107,7 +107,7 @@ cpms_enabled{_id="cluster-id",instance_type="m5.2xlarge",name="osd_exporter"} 1
 			expectedCPMSResults: `
 # HELP cpms_enabled Indicates if the controlplanemachineset is enabled
 # TYPE cpms_enabled gauge
-cpms_enabled{_id="cluster-id",instance_type="m5.2xlarge",name="osd_exporter"} 0
+cpms_enabled{_id="cluster-id",label_beta_kubernetes_io_instance_type="m5.2xlarge",name="osd_exporter"} 0
 `,
 		},
 		{
@@ -119,7 +119,7 @@ cpms_enabled{_id="cluster-id",instance_type="m5.2xlarge",name="osd_exporter"} 0
 			expectedCPMSResults: `
 # HELP cpms_enabled Indicates if the controlplanemachineset is enabled
 # TYPE cpms_enabled gauge
-cpms_enabled{_id="cluster-id",instance_type="custom-4-16384",name="osd_exporter"} 1
+cpms_enabled{_id="cluster-id",label_beta_kubernetes_io_instance_type="custom-4-16384",name="osd_exporter"} 1
 `,
 		},
 		{
@@ -131,7 +131,7 @@ cpms_enabled{_id="cluster-id",instance_type="custom-4-16384",name="osd_exporter"
 			expectedCPMSResults: `
 # HELP cpms_enabled Indicates if the controlplanemachineset is enabled
 # TYPE cpms_enabled gauge
-cpms_enabled{_id="cluster-id",instance_type="custom-4-16384",name="osd_exporter"} 0
+cpms_enabled{_id="cluster-id",label_beta_kubernetes_io_instance_type="custom-4-16384",name="osd_exporter"} 0
 `,
 		},
 	} {

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -9,13 +9,14 @@ import (
 )
 
 const (
-	providerLabel       = "provider"
-	osdExporterValue    = "osd_exporter"
-	proxyHTTPLabel      = "http"
-	proxyHTTPSLabel     = "https"
-	proxyCALabel        = "trusted_ca"
-	proxyCASubjectLabel = "subject"
-	clusterIDLabel      = "_id"
+	providerLabel         = "provider"
+	osdExporterValue      = "osd_exporter"
+	proxyHTTPLabel        = "http"
+	proxyHTTPSLabel       = "https"
+	proxyCALabel          = "trusted_ca"
+	proxyCASubjectLabel   = "subject"
+	clusterIDLabel        = "_id"
+	cpmsInstanceTypeLabel = "instance_type"
 )
 
 var knownIdentityProviderTypes = []configv1.IdentityProviderType{
@@ -116,14 +117,13 @@ func NewMetricsAggregator(aggregationInterval time.Duration, clusterId string) *
 			Name:        "cpms_enabled",
 			Help:        "Indicates if the controlplanemachineset is enabled",
 			ConstLabels: map[string]string{"name": osdExporterValue},
-		}, []string{clusterIDLabel}),
+		}, []string{clusterIDLabel, cpmsInstanceTypeLabel}),
 		providerMap:         make(map[providerKey][]configv1.IdentityProviderType),
 		aggregationInterval: aggregationInterval,
 	}
 	collector.drainingMachines = map[string]drainingMachine{}
 	collector.SetClusterAdmin(clusterId, false)
 	collector.SetLimitedSupport(clusterId, false)
-	collector.SetCPMSEnabled(clusterId, false)
 	return collector
 }
 
@@ -231,9 +231,10 @@ func (a *AdoptionMetricsAggregator) SetClusterProxyCAValid(uuid string, valid bo
 	}
 }
 
-func (a *AdoptionMetricsAggregator) SetCPMSEnabled(uuid string, enabled bool) {
+func (a *AdoptionMetricsAggregator) SetCPMSEnabled(uuid string, instance_type string, enabled bool) {
 	labels := prometheus.Labels{
-		clusterIDLabel: uuid,
+		clusterIDLabel:        uuid,
+		cpmsInstanceTypeLabel: instance_type,
 	}
 	if enabled {
 		a.cpms.With(labels).Set(1)

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -16,7 +16,7 @@ const (
 	proxyCALabel          = "trusted_ca"
 	proxyCASubjectLabel   = "subject"
 	clusterIDLabel        = "_id"
-	cpmsInstanceTypeLabel = "label_beta_kubernetes_io_instance_type"
+	cpmsInstanceTypeLabel = "label_node_kubernetes_io_instance_type"
 )
 
 var knownIdentityProviderTypes = []configv1.IdentityProviderType{

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -16,7 +16,7 @@ const (
 	proxyCALabel          = "trusted_ca"
 	proxyCASubjectLabel   = "subject"
 	clusterIDLabel        = "_id"
-	cpmsInstanceTypeLabel = "instance_type"
+	cpmsInstanceTypeLabel = "label_beta_kubernetes_io_instance_type"
 )
 
 var knownIdentityProviderTypes = []configv1.IdentityProviderType{


### PR DESCRIPTION
The managed fleet has clusters with control plane machine specs that do not match the machine template in the ControlPlaneMachineSet. This label will help to identify clusters with such config drifts.

Part of the enablement of CPMS: https://issues.redhat.com/browse/OSD-21813 

Tested against aws and gcp clusters in stage.