### PR TITLE
only start cpms controller when cpms is installed

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,10 +20,13 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -182,14 +185,26 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&cpms.CPMSReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
-		ClusterId:         clusterId,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "CPMS")
-		os.Exit(1)
+	hasCPMS, err := hasCpmsCrd(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "failed to ensure cpms crd is installed")
+	}
+
+	// To allow the exporter to work on openshift clusters versions < 4.12
+	// and clusters without cpms installed, we check if the cpms CRD is installed
+	// before creating the controller
+	if hasCPMS {
+		if err = (&cpms.CPMSReconciler{
+			Client:            mgr.GetClient(),
+			Scheme:            mgr.GetScheme(),
+			MetricsAggregator: metrics.GetMetricsAggregator(clusterId),
+			ClusterId:         clusterId,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "CPMS")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("ControlPlaneMachineSet CRD not found, skipping cpms controller setup")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -234,4 +249,17 @@ func getClusterID(client client.Reader) (string, error) {
 	}
 
 	return string(cv.Spec.ClusterID), nil
+}
+
+func hasCpmsCrd(config *rest.Config) (bool, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	cpmsGVR := schema.GroupVersionResource{
+		Group:    "machine.openshift.io",
+		Version:  "v1",
+		Resource: "controlplanemachinesets",
+	}
+	return discovery.IsResourceEnabled(client, cpmsGVR)
 }


### PR DESCRIPTION
We have EOL clusters in the managed fleet that do not have cpms installed.
This causes the exporter to crashloop. 

With this change, we check if the 'controlplanemachinesets.machine.openshift.io' CRD is installed and skip starting the cpms controller if its not.

fixes: OSD-22148