### PR TITLE
fix: reset cpms metric on change

### DIFF
--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -236,6 +236,10 @@ func (a *AdoptionMetricsAggregator) SetCPMSEnabled(uuid string, instance_type st
 		clusterIDLabel:        uuid,
 		cpmsInstanceTypeLabel: instance_type,
 	}
+
+	// We need to reset the metric as instance_type can change
+	a.cpms.Reset()
+
 	if enabled {
 		a.cpms.With(labels).Set(1)
 	} else {


### PR DESCRIPTION
CPMS metric is not cleaned up when the instance type in cpms changes. 

Fixes: https://issues.redhat.com/browse/OSD-22497 

Tested against stage.