### PR TITLE
Add FLs and TLs as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,6 +15,8 @@ approvers:
 - iamkirkbater
 - maorfr
 - srep-functional-team-orange
+- srep-functional-leads
+- srep-team-leads
 maintainers:
 - jharrington22
 - dustman9000


### PR DESCRIPTION
Make FLs and TLs approvers for cases where standard approvers aren't suitable/are hard to reach.

Ref [OSD-25197](https://issues.redhat.com//browse/OSD-25197)