### PR TITLE
[OSD-26059] Reset CA metrics between reconciles.

### DIFF
--- a/controllers/configmap/configmap_controller.go
+++ b/controllers/configmap/configmap_controller.go
@@ -52,6 +52,11 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	reqLogger := log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 	reqLogger.Info("Reconciling ConfigMap")
 
+	// Initially reset the metric - old certificates might have been removed
+	// (that were invalid), and not be part of the bundle anymore at all.
+	r.MetricsAggregator.ResetClusterProxyCAExpiry()
+	r.MetricsAggregator.ResetClusterProxyCAValid()
+
 	// Fetch the ConfigMap openshift-config/user-ca-bundle
 	cfgMap := &corev1.ConfigMap{}
 	ns := names.ADDL_TRUST_BUNDLE_CONFIGMAP_NS

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -213,11 +213,21 @@ func (a *AdoptionMetricsAggregator) SetClusterProxy(uuid string, proxyHTTP strin
 	}).Set(float64(proxyEnabled))
 }
 
+// This must be called before setting the new validity of the proxy CA.
+func (a *AdoptionMetricsAggregator) ResetClusterProxyCAExpiry() {
+	a.clusterProxyCAExpiry.Reset()
+}
+
 func (a *AdoptionMetricsAggregator) SetClusterProxyCAExpiry(uuid string, subject string, clusterProxyCAExpiry int64) {
 	a.clusterProxyCAExpiry.With(prometheus.Labels{
 		clusterIDLabel:      uuid,
 		proxyCASubjectLabel: subject,
 	}).Set(float64(clusterProxyCAExpiry))
+}
+
+// This must be called before setting the new validity of the proxy CA.
+func (a *AdoptionMetricsAggregator) ResetClusterProxyCAValid() {
+	a.clusterProxyCAValid.Reset()
 }
 
 func (a *AdoptionMetricsAggregator) SetClusterProxyCAValid(uuid string, valid bool) {


### PR DESCRIPTION
If the metrics are not reset the exporter will keep reporting timestamps for certificates that are no longer present in the bundle.

Added a test to verify this won't happen with the new changes.