### PR TITLE
OSD-26768: enable OLM skip range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ limitations under the License.
 package config
 
 const (
-	OperatorName      = "osd-metrics-exporter"
-	OperatorNamespace = "openshift-osd-metrics"
+	OperatorName       = "osd-metrics-exporter"
+	OperatorNamespace  = "openshift-osd-metrics"
+	EnableOLMSkipRange = "true"
 )


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range pointing to the latest version. This will allow OLM to upgrade past broken replaces chains in which versions get abadoned without a path forward. The new OLM bundle will contain a single version, referencing the latest build with a skipRange to the version.

```
❯ opm render -o yaml quay.io/bpratt/osd-metrics-exporter-registry:production-latest
WARN[0005] DEPRECATION NOTICE:
Sqlite-based catalogs and their related subcommands are deprecated. Support for
them will be removed in a future release. Please migrate your catalog workflows
to the new file-based catalog format.
---
defaultChannel: production
name: osd-metrics-exporter
schema: olm.package
---
entries:
- name: osd-metrics-exporter.v0.1.267-g8f8e0ce
  skipRange: '>=0.0.1 <0.1.267-g8f8e0ce'
name: production
package: osd-metrics-exporter
schema: olm.channel
---
image: ""
name: osd-metrics-exporter.v0.1.267-g8f8e0ce
package: osd-metrics-exporter
properties:
- type: olm.package
  value:
    packageName: osd-metrics-exporter
    version: 0.1.267-g8f8e0ce
- type: olm.bundle.object
...
```

https://v0-18-z.olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange

https://github.com/openshift/boilerplate/tree/8563add3b7f509de3b49ba04863d2708d965b489/boilerplate/openshift/golang-osd-operator#olm-skiprange

https://issues.redhat.com/browse/OSD-26768