### PR TITLE
OSD-29557: Drop defunct optional golangci-lint config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,3 @@ include boilerplate/generated-includes.mk
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
-
-# Enable additional golangci-lint rules
-GOLANGCI_OPTIONAL_CONFIG := .golangci-extras.yml

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . /osd-metrics-exporter
 WORKDIR /osd-metrics-exporter
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 ENV OPERATOR=/usr/local/bin/osd-metrics-exporter \
     USER_UID=1001 \
     USER_NAME=osd-metrics-exporter

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
In https://github.com/openshift/boilerplate/pull/523 we dropped support for `GOLANGCI_OPTIONAL_CONFIG`.

This is one of two repos which was configuring it, however it has been previously removed in https://github.com/openshift/osd-metrics-exporter/commit/8d83dc8851329746949f3d31a2ed87458bbbf042 but the config option was left.

This just cleans that up.