### PR TITLE
Remove the upgrade test from e2e

### DIFF
--- a/test/e2e/osd_metrics_exporter_tests.go
+++ b/test/e2e/osd_metrics_exporter_tests.go
@@ -15,7 +15,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/osd-metrics-exporter/config"
 	"github.com/openshift/osde2e-common/pkg/clients/ocm"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	"github.com/openshift/osde2e-common/pkg/clients/prometheus"
@@ -134,12 +133,6 @@ var _ = ginkgo.Describe("osd-metrics-exporter", ginkgo.Ordered, func() {
 			WithPolling(5*time.Second).
 			WithTimeout(5*time.Minute).
 			Should(BeNumerically("==", 1), "identity_provider metric has not updated")
-	})
-
-	ginkgo.It("can be upgraded", func(ctx context.Context) {
-		ginkgo.By("forcing operator upgrade")
-		err := k8s.UpgradeOperator(ctx, config.OperatorName, config.OperatorNamespace)
-		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
 	})
 })
 


### PR DESCRIPTION
As discussed in this thead (https://redhat-internal.slack.com/archives/CFJD1NZFT/p1749739913929629?thread_ts=1749502449.338289&cid=CFJD1NZFT), we will be removing the upgrade test from e2e to ensure that the OME operator runs on the int clusters. 