### PR TITLE
PKO deployment for OLM cutover

### DIFF
--- a/deploy_pko/Namespace-openshift-osd-metrics.yaml
+++ b/deploy_pko/Namespace-openshift-osd-metrics.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-osd-metrics
-  annotations:
-    package-operator.run/phase: namespace
-    package-operator.run/collision-protection: IfNoController
-  labels:
-    openshift.io/cluster-monitoring: "true"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -28,7 +28,7 @@ objects:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: 'true'
-      resourceApplyMode: Sync
+      resourceApplyMode: Upsert
       applyBehavior: CreateOrUpdate
       resources:
         - apiVersion: v1

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -26,13 +26,19 @@ objects:
         managed.openshift.io/gitHash: ${IMAGE_TAG}
         managed.openshift.io/gitRepoName: ${REPO_NAME}
         managed.openshift.io/osd: "true"
-      name: osd-metrics-exporter-stage
+      name: osd-metrics-exporter-pko
     spec:
       clusterDeploymentSelector:
         matchLabels:
           api.openshift.com/managed: "true"
       resourceApplyMode: Sync
       resources:
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            labels:
+              openshift.io/cluster-monitoring: 'true'
+            name: ${NAMESPACE}
         - apiVersion: package-operator.run/v1alpha1
           kind: ClusterPackage
           metadata:


### PR DESCRIPTION
  - Move Namespace resource from deploy_pko/ into clusterpackage.yaml template
  - Switch SelectorSyncSet resourceApplyMode from Sync to Upsert for more flexible resource management during OLM→PKO cutover
  - Update SelectorSyncSet name from 'osd-metrics-exporter-stage' to 'osd-metrics-exporter-pko' for consistency
  - Enhance OLM cleanup job:
    * Add installplans to RBAC permissions and cleanup script
    * Refactor cleanup script to use variables for better maintainability
    * Update header comments to production-ready format
  - Standardize manifest.yaml structure (properties before type in openAPIV3Schema)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded cleanup to remove additional operator-related resources and support label-parameterized deletions.

* **Chores**
  * Removed a previously provisioned namespace manifest.
  * Adjusted package/sync configuration to add namespace provisioning, rename a selector, and change resource apply behavior to Upsert.
  * Minor schema formatting adjustments and RBAC permission updates to support cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->