### PR TITLE
Prepare PKO deployment for OLM cutover

### DIFF
--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -9,7 +9,6 @@ spec:
   - Cluster
   phases:
   - name: crds
-  - name: namespace
   - name: cleanup-rbac
   - name: cleanup-deploy
   - name: rbac


### PR DESCRIPTION
## Prepare PKO deployment for OLM cutover

This PR prepares osd-metrics-exporter for migration from OLM to PKO (Package Operator) deployment by implementing the correct resource apply mode strategy and consolidating deployment manifests.

### Changes

#### 1. **Consolidate Namespace in SelectorSyncSet** (`hack/pko/clusterpackage.yaml`)
- Moved Namespace definition from `deploy_pko/` into the PKO SelectorSyncSet template
- Updated SelectorSyncSet name from `osd-metrics-exporter-stage` to `osd-metrics-exporter-pko` for consistency
- Uses `resourceApplyMode: Sync` as PKO will be the new owner of resources

#### 2. **Switch OLM to Upsert mode** (`hack/olm-registry/olm-artifacts-template.yaml`)
- Changed OLM SelectorSyncSet from `Sync` to `Upsert` mode
- Prevents resource deletion when the SelectorSyncSet is removed from Hive shards during cutover
- Ensures resources remain on clusters until PKO cleanup job handles them

#### 3. **Remove redundant Namespace file** (`deploy_pko/Namespace-openshift-osd-metrics.yaml`)
- Deleted standalone Namespace manifest (now managed in clusterpackage.yaml)
- Simplifies deployment structure

#### 4. **Fix PKO manifest** (`deploy_pko/manifest.yaml`)
- Removed `namespace` phase since no resources use it anymore
- Fixes PKO deployment failure when phase expects resources but finds none

### Migration Strategy

The combination of these changes ensures a safe OLM→PKO transition:

1. **OLM SelectorSyncSet (Upsert mode)**: When removed from Hive, resources remain on clusters
2. **PKO SelectorSyncSet (Sync mode)**: Takes ownership of resources and deploys PKO
3. **OLM Cleanup Job**: Runs as part of PKO deployment to remove old OLM resources (CSV, Subscription, InstallPlan, CatalogSource, OperatorGroup)

This prevents resource conflicts and allows PKO to cleanly take over management from OLM.

### Testing

- [ ] Verify PKO SelectorSyncSet deploys successfully in integration
- [ ] Confirm OLM cleanup job removes old OLM resources
- [ ] Validate operator functionality after PKO deployment
- [ ] Test promotion pipeline from integration → stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified the deployment manifest for the metrics exporter by removing an unnecessary phase from the deployment control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->