### PR TITLE
Fix PKO phase ordering for cleanup jobs

### DIFF
--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -9,10 +9,10 @@ spec:
   - Cluster
   phases:
   - name: crds
-  - name: cleanup-rbac
-  - name: cleanup-deploy
   - name: rbac
   - name: deploy
+  - name: cleanup-rbac
+  - name: cleanup-deploy
   availabilityProbes:
   - probes:
     - condition:


### PR DESCRIPTION
## Summary
- Fix phase ordering in PKO manifest to execute cleanup phases after operator deployment
- This resolves ClusterPackage failures with "namespace not found" errors during cleanup-rbac phase

## Problem
The ClusterPackage was failing at the `cleanup-rbac` phase with error:
```
namespaces "openshift-osd-metrics" not found
```

Root cause: Cleanup phases were running before the operator deployment, attempting to create RBAC resources (ServiceAccount, Role, RoleBinding) for the cleanup job in a namespace that doesn't exist yet.

## Solution
Reordered phases to execute cleanup AFTER operator deployment:

**Before:**
```yaml
phases:
  - name: crds
  - name: cleanup-rbac
  - name: cleanup-deploy
  - name: rbac
  - name: deploy
```

**After:**
```yaml
phases:
  - name: crds
  - name: rbac
  - name: deploy
  - name: cleanup-rbac
  - name: cleanup-deploy
```

This aligns with other operators like `configure-alertmanager-operator` where cleanup phases run after deployment.

## Testing
- Deploy to integration cluster with failing ClusterPackage
- Verify ClusterPackage progresses past cleanup-rbac phase
- Confirm cleanup job completes successfully

## References
- Compared with configure-alertmanager-operator phase ordering
- PKO archive operation runs phases in reverse on upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered deployment and cleanup phases to execute cleanup operations after deployment completion, improving operational sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->