### PR TITLE
Fix OLM cleanup job: correct deletion order and add ttl

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . /osd-metrics-exporter
 WORKDIR /osd-metrics-exporter
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776645941
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
 ENV OPERATOR=/usr/local/bin/osd-metrics-exporter \
     USER_UID=1001 \
     USER_NAME=osd-metrics-exporter

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776645941
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -65,6 +65,7 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:
@@ -84,13 +85,13 @@ spec:
               #!/bin/sh
               set -euxo pipefail
 
+              # Delete Subscription first so it cannot recreate the CSV
+              echo "Deleting Subscription for osd-metrics-exporter..."
+              oc -n openshift-osd-metrics delete subscription.operators.coreos.com osd-metrics-exporter || true
+
               # Delete ClusterServiceVersion(s) for osd-metrics-exporter
               echo "Deleting CSV for osd-metrics-exporter..."
               oc -n openshift-osd-metrics delete csv -l "operators.coreos.com/osd-metrics-exporter.openshift-osd-metrics" || true
-
-              # Delete Subscription
-              echo "Deleting Subscription for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete subscription.operators.coreos.com osd-metrics-exporter || true
 
               # Delete CatalogSource
               echo "Deleting CatalogSource for osd-metrics-exporter..."

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -1,12 +1,10 @@
 ---
-# This Job cleans up old OLM resources after migrating to PKO
-# IMPORTANT: Review and customize this template before deploying!
-# 
-# Things to customize:
-# 1. Adjust the namespace if needed
-# 2. Modify resource filters (CSV names, labels, etc.)
-# 3. Review RBAC permissions
-# 4. Update the cleanup logic for your specific operator
+# This Job cleans up OLM resources after migrating to PKO
+# Resources cleaned up:
+#   - Subscription
+#   - ClusterServiceVersion (CSV)
+#   - CatalogSource
+#   - OperatorGroup
 #
 apiVersion: v1
 kind: ServiceAccount
@@ -38,6 +36,12 @@ rules:
       - get
       - watch
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -85,19 +89,42 @@ spec:
               #!/bin/sh
               set -euxo pipefail
 
+              ERRORS=""
+              NS="openshift-osd-metrics"
+
               # Delete Subscription first so OLM cannot recreate the CSV
-              echo "Deleting Subscription for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete subscription.operators.coreos.com osd-metrics-exporter --ignore-not-found --wait || true
+              oc -n "$NS" delete subscription.operators.coreos.com osd-metrics-exporter --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete Subscription. "
 
               # Delete ClusterServiceVersion(s) - safe now that Subscription is gone
-              echo "Deleting CSV for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete csv -l "operators.coreos.com/osd-metrics-exporter.openshift-osd-metrics" --ignore-not-found --wait || true
+              oc -n "$NS" delete csv -l "operators.coreos.com/osd-metrics-exporter.${NS}" --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
 
               # Delete CatalogSource
-              echo "Deleting CatalogSource for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete catalogsource.operators.coreos.com osd-metrics-exporter-registry --ignore-not-found --wait || true
+              oc -n "$NS" delete catalogsource.operators.coreos.com osd-metrics-exporter-registry --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
-              echo "OLM cleanup complete"
+              # Delete OperatorGroup
+              oc -n "$NS" delete operatorgroup osd-metrics-exporter --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete OperatorGroup. "
+
+              if [ -n "$ERRORS" ]; then
+                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
+                oc create -f - <<EVENTEOF || true
+              apiVersion: v1
+              kind: Event
+              metadata:
+                generateName: olm-cleanup-warning-
+                namespace: ${NS}
+              involvedObject:
+                apiVersion: v1
+                kind: Namespace
+                name: ${NS}
+              reason: OLMCleanupErrors
+              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              type: Warning
+              EVENTEOF
+              fi
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -79,7 +79,7 @@ spec:
       priorityClassName: openshift-user-critical
       restartPolicy: Never
       containers:
-        - name: delete-csv
+        - name: olm-cleanup
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
           imagePullPolicy: Always
           command:

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -85,17 +85,17 @@ spec:
               #!/bin/sh
               set -euxo pipefail
 
-              # Delete Subscription first so it cannot recreate the CSV
+              # Delete Subscription first so OLM cannot recreate the CSV
               echo "Deleting Subscription for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete subscription.operators.coreos.com osd-metrics-exporter || true
+              oc -n openshift-osd-metrics delete subscription.operators.coreos.com osd-metrics-exporter --ignore-not-found --wait
 
-              # Delete ClusterServiceVersion(s) for osd-metrics-exporter
+              # Delete ClusterServiceVersion(s) - safe now that Subscription is gone
               echo "Deleting CSV for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete csv -l "operators.coreos.com/osd-metrics-exporter.openshift-osd-metrics" || true
+              oc -n openshift-osd-metrics delete csv -l "operators.coreos.com/osd-metrics-exporter.openshift-osd-metrics" --ignore-not-found --wait
 
               # Delete CatalogSource
               echo "Deleting CatalogSource for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete catalogsource.operators.coreos.com osd-metrics-exporter-registry || true
+              oc -n openshift-osd-metrics delete catalogsource.operators.coreos.com osd-metrics-exporter-registry --ignore-not-found --wait
 
               echo "OLM cleanup complete"
           resources:

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -87,15 +87,15 @@ spec:
 
               # Delete Subscription first so OLM cannot recreate the CSV
               echo "Deleting Subscription for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete subscription.operators.coreos.com osd-metrics-exporter --ignore-not-found --wait
+              oc -n openshift-osd-metrics delete subscription.operators.coreos.com osd-metrics-exporter --ignore-not-found --wait || true
 
               # Delete ClusterServiceVersion(s) - safe now that Subscription is gone
               echo "Deleting CSV for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete csv -l "operators.coreos.com/osd-metrics-exporter.openshift-osd-metrics" --ignore-not-found --wait
+              oc -n openshift-osd-metrics delete csv -l "operators.coreos.com/osd-metrics-exporter.openshift-osd-metrics" --ignore-not-found --wait || true
 
               # Delete CatalogSource
               echo "Deleting CatalogSource for osd-metrics-exporter..."
-              oc -n openshift-osd-metrics delete catalogsource.operators.coreos.com osd-metrics-exporter-registry --ignore-not-found --wait
+              oc -n openshift-osd-metrics delete catalogsource.operators.coreos.com osd-metrics-exporter-registry --ignore-not-found --wait || true
 
               echo "OLM cleanup complete"
           resources:


### PR DESCRIPTION
## Summary
- Fix deletion order in the OLM cleanup job: **Subscription must be deleted before CSV** to prevent the Subscription controller from recreating the CSV before it can be removed
- Add `ttlSecondsAfterFinished: 100` to prevent a completed or failed job from lingering and blocking same-named jobs from new PKO package rollouts

## Deletion order (before → after)
| Before | After |
|--------|-------|
| CSV → Subscription → CatalogSource | Subscription → CSV → CatalogSource |

## Test plan
- [ ] Verify cleanup job runs successfully on a canary hive after OLM-to-PKO cutover
- [ ] Confirm Subscription, CSV, and CatalogSource are all removed post-cleanup
- [ ] Confirm job is auto-deleted after 100s (ttl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reordered cleanup steps to prevent resource recreation and surface failures via namespace warning events.

* **Chores**
  * Enabled automatic garbage collection for cleanup jobs (100s post-completion).
  * Updated the base runtime image used by Docker builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->