### PR TITLE
[DRAFT] - Add ome_secret.yml to set SKIP_INFRASTRUCTURE_HEALTH_CHECK for e2e

### DIFF
--- a/test/e2e/ome_secret.yml
+++ b/test/e2e/ome_secret.yml
@@ -1,0 +1,14 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: template
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: osd-metrics-exporter-sc
+  stringData:
+    SKIP_INFRASTRUCTURE_HEALTH_CHECK: ${SKIP_INFRASTRUCTURE_HEALTH_CHECK}
+parameters:
+- name: SKIP_INFRASTRUCTURE_HEALTH_CHECK
+  value: "true"


### PR DESCRIPTION
osde2e fails with "aws variables were not set" when the infrastructure health check runs without AWS credentials. RMO skips this check via a secret mounted at /etc/external-secrets. This adds an equivalent secret template for OME so the e2e pipeline matches RMO's working setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test infrastructure configuration for OpenShift secret management with configurable parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->