### PR TITLE
fix: remove ttlSecondsAfterFinished from olm-cleanup Job

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -69,7 +69,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:


### PR DESCRIPTION
## Problem

After the OLM→PKO migration, every subsequent PKO revision rollout was stuck with:

```
Job.batch "olm-cleanup" is invalid: spec.template: field is immutable
```

`ttlSecondsAfterFinished: 100` was causing the `olm-cleanup` Job to be deleted after completion. The serving `ClusterObjectSet` immediately recreates it. When a new revision tries to adopt the freshly created (not yet Complete) Job, PKO attempts a full spec apply — Kubernetes rejects this because `job.spec.template` is immutable after creation. Kubernetes auto-injects `controller-uid`/`job-name` labels into the pod template on creation, creating a diff that can never be reconciled.

This blocked **all** PKO revision rollouts on every affected cluster after initial migration. On the integration cluster (`hs-mc-s73a68sgg`) this had been silently failing for **46 days** across 15 revisions.

## Root cause

`route-monitor-operator` has an identical `olm-cleanup` Job but has **never had this issue** — because it has no `ttlSecondsAfterFinished`. Its Job stays permanently Complete. PKO skips the spec apply on Complete Jobs and only transfers the owner reference (a metadata-only patch), which is always allowed.

## Fix

Remove `ttlSecondsAfterFinished: 100`. The Job stays permanently Complete between revisions, matching the RMO pattern.

```diff
-  ttlSecondsAfterFinished: 100
```

## Validation

Tested end-to-end on `hs-mc-s73a68sgg` (integration cluster):
- Revision 18 adopted the existing `olm-cleanup` Job (Complete) without any immutability error
- `ClusterPackage Available: True — Latest Revision is Available` ✓
- `Progressing: False — Update concluded` ✓
- Running image updated from `1d9c46e` → `226da0e` ✓

## Test plan

- [ ] Konflux CI passes
- [ ] Confirm `ClusterPackage` reaches `Available: True — Latest Revision is Available` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)