### PR TITLE
SREP-4556: Add terminationMessagePolicy for OCP 4.21 conformance

### DIFF
--- a/deploy/30_osd-metrics-exporter_openshift-osd-metrics.Deployment.yaml
+++ b/deploy/30_osd-metrics-exporter_openshift-osd-metrics.Deployment.yaml
@@ -32,6 +32,7 @@ spec:
           command:
             - osd-metrics-exporter
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -81,6 +81,7 @@ spec:
         - name: olm-cleanup
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - sh
             - -c

--- a/deploy_pko/Deployment-osd-metrics-exporter.yaml.gotmpl
+++ b/deploy_pko/Deployment-osd-metrics-exporter.yaml.gotmpl
@@ -35,6 +35,7 @@ spec:
         command:
         - osd-metrics-exporter
         imagePullPolicy: Always
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Adds terminationMessagePolicy: FallbackToLogsOnError to all containers in deploy/ and deploy_pko/ manifests. Required for OCP 4.21 conformance (terminationMessagePolicy monitor test).

Jira: https://redhat.atlassian.net/browse/SREP-4556
Reference: openshift/route-monitor-operator#516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container error reporting in deployment configurations to provide better troubleshooting information during system issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->