### PR TITLE
Fix cleanup Job immutability and improve resilience for transient failures

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -63,12 +63,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-{{ .config.version }}
   namespace: openshift-osd-metrics
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  backoffLimit: 40
   template:
     metadata:
       annotations:
@@ -76,7 +76,7 @@ spec:
     spec:
       serviceAccountName: olm-cleanup
       priorityClassName: openshift-user-critical
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: olm-cleanup
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -93,24 +93,24 @@ spec:
               NS="openshift-osd-metrics"
 
               # Delete Subscription first so OLM cannot recreate the CSV
-              oc -n "$NS" delete subscription.operators.coreos.com osd-metrics-exporter --ignore-not-found=true \
+              oc -n "$NS" delete subscription.operators.coreos.com osd-metrics-exporter --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete Subscription. "
 
               # Delete ClusterServiceVersion(s) - safe now that Subscription is gone
-              oc -n "$NS" delete csv -l "operators.coreos.com/osd-metrics-exporter.${NS}" --ignore-not-found=true \
+              oc -n "$NS" delete csv -l "operators.coreos.com/osd-metrics-exporter.${NS}" --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CSV. "
 
               # Delete CatalogSource
-              oc -n "$NS" delete catalogsource.operators.coreos.com osd-metrics-exporter-registry --ignore-not-found=true \
+              oc -n "$NS" delete catalogsource.operators.coreos.com osd-metrics-exporter-registry --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
               # Delete OperatorGroup
-              oc -n "$NS" delete operatorgroup osd-metrics-exporter --ignore-not-found=true \
+              oc -n "$NS" delete operatorgroup osd-metrics-exporter --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete OperatorGroup. "
 
               if [ -n "$ERRORS" ]; then
-                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
-                oc create -f - <<EVENTEOF || true
+                echo "ERROR: OLM cleanup failed, will retry: ${ERRORS}" >&2
+                oc create -f - <<EVENTEOF || echo "Failed to create warning event" >&2
               apiVersion: v1
               kind: Event
               metadata:
@@ -121,9 +121,10 @@ spec:
                 kind: Namespace
                 name: ${NS}
               reason: OLMCleanupErrors
-              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              message: "OLM cleanup job failed, will retry: ${ERRORS}"
               type: Warning
               EVENTEOF
+                exit 1
               fi
           resources:
             requests:

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -32,4 +32,10 @@ spec:
         image:
           description: Operator image to deploy
           type: string
-          default: None
+          default: ""
+        version:
+          description: Operator version tag for resource naming
+          type: string
+          default: "0000000"
+          pattern: "^[a-z0-9][a-z0-9.-]*$"
+          maxLength: 51

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -49,3 +49,4 @@ objects:
             image: ${PKO_IMAGE}:${IMAGE_TAG}
             config:
               image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
+              version: ${IMAGE_TAG}


### PR DESCRIPTION
## Summary

- Add version suffix to cleanup Job name (`olm-cleanup-{{ .config.version }}`) to prevent Kubernetes Job immutability errors on operator upgrades
- Switch `restartPolicy` from `Never` to `OnFailure` so image pull failures retry indefinitely without consuming `backoffLimit`
- Set `backoffLimit: 40` for ~3 hours of script-level retries with exponential backoff
- Add `--timeout=300s` to each `oc delete` command to bound stuck finalizers
- Exit non-zero on errors so `OnFailure` triggers a retry
- Add `version` config parameter to `manifest.yaml` and `clusterpackage.yaml` (required by the Job template)

## Context

The ClusterPackage is stuck progressing with:
```
Job.batch "olm-cleanup" is invalid: spec.template: Invalid value: field is immutable
```

The static Job name `olm-cleanup` blocks PKO revision transitions. Kubernetes auto-injects UID-based labels (`batch.kubernetes.io/controller-uid`) into the Job's pod template at creation time. These labels are part of the immutable `spec.template`. When PKO deploys a new revision and tries to reconcile the existing Job, the desired state doesn't match the auto-injected labels, and Kubernetes rejects the update.

The version-suffixed name (`olm-cleanup-{{ .config.version }}`) creates a unique Job per revision, sidestepping immutability. The old Job is archived with the previous ObjectSet.

The resilience improvements (`restartPolicy: OnFailure`, `backoffLimit`, per-command timeouts) address a separate issue where cleanup Jobs permanently fail on clusters with a degraded internal image registry — the pod can't pull the CLI image and the Job never retries.

These are the same fixes applied to configure-alertmanager-operator in PRs #519 and #527.

## Test plan

- [x] `go build ./...` passes
- [ ] CI passes
- [ ] Verify: new Job name includes version suffix
- [ ] Verify: ClusterPackage progresses past cleanup-deploy phase after upgrade

## References

- CAMO PR #519 (version-based naming): https://github.com/openshift/configure-alertmanager-operator/pull/519
- CAMO PR #527 (resilience): https://github.com/openshift/configure-alertmanager-operator/pull/527