### PR TITLE
Scope group RBAC to least privilege

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ COPY . /osd-metrics-exporter
 WORKDIR /osd-metrics-exporter
 RUN make go-build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 ENV OPERATOR=/usr/local/bin/osd-metrics-exporter \
     USER_UID=1001 \
     USER_NAME=osd-metrics-exporter

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786380870
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/group/group_controller.go
+++ b/controllers/group/group_controller.go
@@ -65,8 +65,9 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 	if group.DeletionTimestamp.IsZero() {
 		if !utils.ContainsString(group.Finalizers, finalizer) {
+			original := group.DeepCopy()
 			controllerutil.AddFinalizer(group, finalizer)
-			if err := r.Update(ctx, group); err != nil {
+			if err := r.Patch(ctx, group, client.MergeFrom(original)); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -74,8 +75,9 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	} else {
 		r.MetricsAggregator.SetClusterAdmin(r.ClusterId, false)
 		if utils.ContainsString(group.Finalizers, finalizer) {
+			original := group.DeepCopy()
 			controllerutil.RemoveFinalizer(group, finalizer)
-			if err := r.Update(ctx, group); err != nil {
+			if err := r.Patch(ctx, group, client.MergeFrom(original)); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/deploy/10_osd-metrics-exporter.ClusterRole.yaml
+++ b/deploy/10_osd-metrics-exporter.ClusterRole.yaml
@@ -48,7 +48,14 @@ rules:
       - get
       - list
       - watch
-      - update
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - groups
+    resourceNames:
+      - cluster-admins
+    verbs:
+      - patch
   - apiGroups:
       - machine.openshift.io
     resources:

--- a/deploy_pko/ClusterRole-osd-metrics-exporter-watch-clusterscope.yaml
+++ b/deploy_pko/ClusterRole-osd-metrics-exporter-watch-clusterscope.yaml
@@ -49,7 +49,14 @@ rules:
   - get
   - list
   - watch
-  - update
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  resourceNames:
+  - cluster-admins
+  verbs:
+  - patch
 - apiGroups:
   - machine.openshift.io
   resources:


### PR DESCRIPTION
## Summary
- The `GroupReconciler` only manages a finalizer on the `cluster-admins` Group, but the ClusterRole granted `update` on **all** `user.openshift.io/groups` cluster-wide with no `resourceNames` restriction.
- Split the groups RBAC rule: read verbs (`get`/`list`/`watch`) remain unrestricted for the informer; write access is now `patch`-only and scoped to `resourceNames: [cluster-admins]`.
- Switched the controller from `Update` to `Patch` (`MergeFrom`) so only the metadata diff is sent, matching the new RBAC verb.
- Applied the same change to both `deploy/` and `deploy_pko/` ClusterRole manifests.

## Test plan
- [x] All existing unit tests pass (`go test ./...`)
- [ ] Verify on a test cluster that the finalizer is still correctly added/removed on the `cluster-admins` Group
- [ ] Confirm the metrics exporter pod starts without RBAC errors

[ROSAENG-61318](https://redhat.atlassian.net/browse/ROSAENG-61318)

[ROSAENG-61318]: https://redhat.atlassian.net/browse/ROSAENG-61318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ